### PR TITLE
Release 2024-01-24

### DIFF
--- a/hancestro-base.json
+++ b/hancestro-base.json
@@ -22,9 +22,9 @@
         "val" : "http://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2023-10-13"
+        "val" : "2024-01-24"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro-base.json"
+      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro-base.json"
     },
     "nodes" : [ {
       "id" : "http://dbpedia.org/resource/Afghanistan",
@@ -33,6 +33,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00006882"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Africa",
+      "lbl" : "Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000457"
         } ]
       }
     }, {
@@ -123,6 +132,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00004025"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Asia",
+      "lbl" : "Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000465"
         } ]
       }
     }, {
@@ -355,6 +373,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Caribbean",
+      "lbl" : "Caribbean",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Cayman_Islands",
       "lbl" : "Cayman Islands",
       "type" : "CLASS",
@@ -370,6 +392,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00001089"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Central_America",
+      "lbl" : "Central America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002891"
         } ]
       }
     }, {
@@ -557,6 +588,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Africa",
+      "lbl" : "Eastern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000556"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Asia",
+      "lbl" : "Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002471"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Europe",
+      "lbl" : "Eastern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Ecuador",
       "lbl" : "Ecuador",
       "type" : "CLASS",
@@ -617,6 +670,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000567"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Europe",
+      "lbl" : "Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000464"
         } ]
       }
     }, {
@@ -1049,6 +1111,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "lbl" : "Latin America and the Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Latvia",
       "lbl" : "Latvia",
       "type" : "CLASS",
@@ -1241,6 +1312,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Melanesia",
+      "lbl" : "Melanesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005860"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Mexico",
       "lbl" : "Mexico",
       "type" : "CLASS",
@@ -1249,6 +1329,19 @@
           "val" : "GAZ:00002852"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Micronesia",
+      "lbl" : "Micronesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005862"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Middle_Africa",
+      "lbl" : "Middle Africa",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Moldova",
       "lbl" : "Moldova",
@@ -1455,6 +1548,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Northern_Africa",
+      "lbl" : "Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000555"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_America",
+      "lbl" : "Northern America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000458"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_Europe",
+      "lbl" : "Northern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "lbl" : "Northern Mariana Islands",
       "type" : "CLASS",
@@ -1474,6 +1589,15 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
           "val" : "Kingdom of Norway"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Oceania",
+      "lbl" : "Oceania",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000468"
         } ]
       }
     }, {
@@ -1589,6 +1713,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00002939"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Polynesia",
+      "lbl" : "Polynesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005861"
         } ]
       }
     }, {
@@ -1795,6 +1928,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Scandinavia",
+      "lbl" : "Scandinavia",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Scotland",
       "lbl" : "Scotland",
       "type" : "CLASS",
@@ -1894,12 +2031,43 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "lbl" : "South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000559"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South-central_Asia",
+      "lbl" : "South-Central Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/SouthAmerica",
+      "lbl" : "South America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/South_Africa",
       "lbl" : "South Africa",
       "type" : "CLASS",
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South_Asia",
+      "lbl" : "South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002472"
         } ]
       }
     }, {
@@ -1924,6 +2092,19 @@
           "val" : "GAZ:00233439"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Africa",
+      "lbl" : "Southern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Europe",
+      "lbl" : "Southern Europe",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Spain",
       "lbl" : "Spain",
@@ -2281,6 +2462,23 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Western_Africa",
+      "lbl" : "Western Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000554"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Asia",
+      "lbl" : "Western Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Europe",
+      "lbl" : "Western Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Western_Sahara",
       "lbl" : "Western Sahara",
       "type" : "CLASS",
@@ -2343,19 +2541,13 @@
       "lbl" : "has_part",
       "type" : "PROPERTY"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000374",
+      "id" : "http://purl.obolibrary.org/obo/GAZ_00000013",
       "lbl" : "continent",
       "type" : "CLASS",
       "meta" : {
-        "definition" : {
-          "val" : "One of the large, unbroken masses of land into which the Earth's surface is divided."
-        },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "major area"
-        } ],
-        "xrefs" : [ {
-          "val" : "GAZ:00190836"
         } ]
       }
     }, {
@@ -2373,7 +2565,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "lbl" : "country",
+      "lbl" : "obsolete country",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -2382,7 +2574,11 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "NCIT:C25464"
-        } ]
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
@@ -2588,152 +2784,234 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "lbl" : "Africa",
+      "lbl" : "obsolete Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000457"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "lbl" : "Asia",
+      "lbl" : "obsolete Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000465"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "lbl" : "Europe",
+      "lbl" : "obsolete Europe",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000464"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Europe"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "lbl" : "Oceania",
+      "lbl" : "obsolete Oceania",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000468"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Oceania"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "lbl" : "Latin America and the Caribbean",
+      "lbl" : "obsolete Latin America and the Caribbean",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "lbl" : "Northern America",
+      "lbl" : "obsolete Northern America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000458"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "lbl" : "Eastern Africa",
+      "lbl" : "obsolete Eastern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000556"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "lbl" : "Middle Africa",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "lbl" : "Northern Africa",
+      "lbl" : "obsolete Middle Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000555"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Middle_Africa"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
+      "lbl" : "obsolete Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "lbl" : "Southern Africa",
+      "lbl" : "obsolete Southern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000553"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "lbl" : "Western Africa",
+      "lbl" : "obsolete Western Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000554"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "lbl" : "South-Central Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "lbl" : "South-Eastern Asia",
+      "lbl" : "obsolete South Central Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000559"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-central_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
+      "lbl" : "obsolete South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "lbl" : "Western Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "lbl" : "Eastern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "lbl" : "Northern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "lbl" : "Southern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "lbl" : "Western Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "lbl" : "Caribbean",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "lbl" : "South America",
+      "lbl" : "obsolete Western Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
+      "lbl" : "obsolete Eastern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
+      "lbl" : "obsolete Northern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
+      "lbl" : "obsolete Southern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
+      "lbl" : "obsolete Western Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
+      "lbl" : "obsolete Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Caribbean"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
+      "lbl" : "obsolete South America",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/SouthAmerica"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "lbl" : "Central America",
+      "lbl" : "obsolete Central America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002891"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Central_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
@@ -2741,39 +3019,47 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "lbl" : "Melanesia",
+      "lbl" : "obsolete Melanesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005860"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Melanesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "lbl" : "Micronesia",
+      "lbl" : "obsolete Micronesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005862"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Micronesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "lbl" : "Polynesia",
+      "lbl" : "obsolete Polynesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005861"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Polynesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-      "lbl" : "Eastern Asia",
+      "lbl" : "obsolete Eastern Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002471"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0286",
@@ -2793,16 +3079,25 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "lbl" : "Scandinavia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "lbl" : "South Asia",
+      "lbl" : "obsolete Scandinavia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002472"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Scandinavia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
+      "lbl" : "obsolete South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
@@ -4246,6 +4541,10 @@
       "lbl" : "term replaced by",
       "type" : "PROPERTY"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/NCIT_C25464",
+      "lbl" : "Country",
+      "type" : "CLASS"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/RO_0001015",
       "lbl" : "location_of",
       "type" : "PROPERTY"
@@ -4272,2337 +4571,1079 @@
     "edges" : [ {
       "sub" : "http://dbpedia.org/resource/Afghanistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Albania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Algeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/American_Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Andorra",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Angola",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Anguilla",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Argentina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Armenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Aruba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Australia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Austria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Azerbaijan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bahrain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bangladesh",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Barbados",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belarus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belgium",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belize",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Benin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bermuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bhutan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bolivia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Botswana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brazil",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brunei",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bulgaria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burkina_Faso",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burundi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cambodia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cameroon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Canada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cape_Verde",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Cayman_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Central_African_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Central_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Chad",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Channel_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Chile",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/China",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Christmas_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Colombia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Comoros",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cook_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Costa_Rica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Croatia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cuba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Curacao",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cyprus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Czech_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Denmark",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Djibouti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominican_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/East_Timor",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Ecuador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Egypt",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/El_Salvador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Eritrea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Estonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ethiopia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Falkland_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Fiji",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Finland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/France",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Guiana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Polynesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gabon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Germany",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ghana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gibraltar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greece",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greenland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Grenada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guadeloupe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guatemala",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guyana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Haiti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Holy_See",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Honduras",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hong_Kong",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hungary",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iceland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/India",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Indonesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iran",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iraq",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Isle_of_Man",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Israel",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Italy",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ivory_Coast",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jamaica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Japan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jordan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kazakhstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kenya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kiribati",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kosovo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kuwait",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Laos",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Latvia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lebanon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lesotho",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liberia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Libya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liechtenstein",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lithuania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Luxembourg",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Macau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Madagascar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malawi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malaysia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Maldives",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mali",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malta",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Marshall_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Martinique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauretania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauritius",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mayotte",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Melanesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Mexico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Micronesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Middle_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Moldova",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Monaco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mongolia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montenegro",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montserrat",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Morocco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mozambique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Myanmar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Namibia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nauru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nepal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Caledonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Zealand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nicaragua",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niger",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nigeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niue",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norfolk_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/North_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norway",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Oceania",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Oman",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pakistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palestinian_territories",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Panama",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Paraguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Peru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Philippines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Poland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Polynesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Portugal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Puerto_Rico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Qatar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Romania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Russia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Rwanda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Réunion",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Helena",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Lucia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Martin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/San_Marino",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Scandinavia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Scotland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Senegal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Serbia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Seychelles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sierra_Leone",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Singapore",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sint_Maarten",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovakia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Solomon_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Somalia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-central_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/SouthAmerica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Africa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Spain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sri_Lanka",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Suriname",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Swaziland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sweden",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Switzerland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Syria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Taiwan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tajikistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tanzania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Thailand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Bahamas",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Gambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Togo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tokelau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tonga",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tunisia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkey",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkmenistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tuvalu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uganda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ukraine",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Kingdom",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uruguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uzbekistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vanuatu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Venezuela",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vietnam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Western_Sahara",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Yemen",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zimbabwe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Georgia_(country)",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
       "pred" : "is_a",
-      "obj" : "http://www.w3.org/2002/07/owl#Thing"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "pred" : "is_a",
-      "obj" : "http://www.w3.org/2002/07/owl#Thing"
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
       "pred" : "is_a",
-      "obj" : "http://www.w3.org/2002/07/owl#Thing"
+      "obj" : "http://purl.obolibrary.org/obo/OBI_0000181"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0005",
       "pred" : "is_a",
@@ -6732,107 +5773,7 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0021"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
@@ -6840,17 +5781,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0004"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0304",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/BFO_0000019"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0305",
       "pred" : "is_a",
@@ -6866,13 +5803,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0307",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Italy",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Italy"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0309",
       "pred" : "is_a",
@@ -6928,13 +5859,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0321",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Finland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Finland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0322",
       "pred" : "is_a",
@@ -6950,203 +5875,83 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Western_Sahara",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Western_Sahara"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Anguilla",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Anguilla"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Barbados",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Barbados"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Haiti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Haiti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jamaica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jamaica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tajikistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tajikistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkmenistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkmenistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uzbekistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uzbekistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "is_a",
@@ -7154,53 +5959,23 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Afghanistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Afghanistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kazakhstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kazakhstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kyrgyzstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kyrgyzstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "is_a",
@@ -7208,13 +5983,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Albania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Albania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "is_a",
@@ -7222,13 +5991,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Andorra",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Andorra"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "is_a",
@@ -7236,13 +5999,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Australia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Australia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "is_a",
@@ -7250,13 +6007,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Austria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Austria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "is_a",
@@ -7264,13 +6015,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belarus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belarus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "is_a",
@@ -7278,13 +6023,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belgium",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belgium"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "is_a",
@@ -7292,13 +6031,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bermuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bermuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "is_a",
@@ -7306,13 +6039,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "is_a",
@@ -7320,13 +6047,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brazil",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brazil"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "is_a",
@@ -7334,13 +6055,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bulgaria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bulgaria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "is_a",
@@ -7348,13 +6063,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Canada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Canada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "is_a",
@@ -7362,13 +6071,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Channel_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Channel_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "is_a",
@@ -7376,13 +6079,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chile",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chile"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "is_a",
@@ -7390,13 +6087,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Croatia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Croatia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "is_a",
@@ -7404,13 +6095,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Czech_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Czech_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "is_a",
@@ -7418,13 +6103,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Denmark",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Denmark"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "is_a",
@@ -7432,13 +6111,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Estonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Estonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "is_a",
@@ -7446,13 +6119,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Faeroe_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Faeroe_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "is_a",
@@ -7460,13 +6127,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Falkland_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Falkland_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "is_a",
@@ -7474,13 +6135,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/France",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/France"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "is_a",
@@ -7488,13 +6143,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Germany",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Germany"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "is_a",
@@ -7502,13 +6151,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gibraltar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gibraltar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "is_a",
@@ -7516,13 +6159,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greece",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greece"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "is_a",
@@ -7530,13 +6167,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greenland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greenland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "is_a",
@@ -7544,13 +6175,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Hungary",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Hungary"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "is_a",
@@ -7558,13 +6183,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iceland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iceland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "is_a",
@@ -7572,13 +6191,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Isle_of_Man",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Isle_of_Man"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "is_a",
@@ -7586,13 +6199,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Latvia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Latvia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "is_a",
@@ -7600,13 +6207,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liechtenstein",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liechtenstein"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "is_a",
@@ -7614,13 +6215,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lithuania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lithuania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "is_a",
@@ -7628,13 +6223,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Luxembourg",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Luxembourg"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "is_a",
@@ -7642,13 +6231,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malta",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malta"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "is_a",
@@ -7656,13 +6239,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Monaco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Monaco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "is_a",
@@ -7670,13 +6247,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montenegro",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montenegro"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "is_a",
@@ -7684,33 +6255,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Zealand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Zealand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norfolk_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norfolk_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "is_a",
@@ -7718,13 +6271,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norway",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norway"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "is_a",
@@ -7732,13 +6279,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Poland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Poland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "is_a",
@@ -7746,13 +6287,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Portugal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Portugal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "is_a",
@@ -7760,13 +6295,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "is_a",
@@ -7774,13 +6303,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Moldova",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Moldova"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "is_a",
@@ -7788,33 +6311,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Romania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Romania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Russia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Russia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "is_a",
@@ -7822,13 +6327,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "is_a",
@@ -7836,13 +6335,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/San_Marino",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/San_Marino"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "is_a",
@@ -7850,13 +6343,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Serbia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Serbia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "is_a",
@@ -7864,13 +6351,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovakia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovakia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "is_a",
@@ -7878,13 +6359,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "is_a",
@@ -7892,13 +6367,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Spain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Spain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "is_a",
@@ -7906,13 +6375,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sweden",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sweden"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "is_a",
@@ -7920,13 +6383,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Switzerland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Switzerland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "is_a",
@@ -7934,13 +6391,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "is_a",
@@ -7948,1313 +6399,527 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ukraine",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ukraine"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Argentina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Argentina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Bahamas",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Bahamas"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belize",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belize"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bolivia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bolivia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cayman_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cayman_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Colombia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Colombia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Costa_Rica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Costa_Rica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cuba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cuba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Dominica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Dominica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ecuador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ecuador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/El_Salvador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/El_Salvador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Guiana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Guiana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Grenada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Grenada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guatemala",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guatemala"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guyana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guyana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Honduras",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Honduras"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Martinique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Martinique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mexico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mexico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montserrat",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montserrat"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nicaragua",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nicaragua"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Panama",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Panama"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Paraguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Paraguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Peru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Peru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Puerto_Rico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Puerto_Rico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Lucia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Lucia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Suriname",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Suriname"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uruguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uruguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Venezuela",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Venezuela"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Algeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Algeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Armenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Armenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Azerbaijan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Azerbaijan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bahrain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bahrain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cyprus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cyprus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Egypt",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Egypt"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Georgia_(country)",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Georgia_(country)"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iran",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iran"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iraq",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iraq"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Israel",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Israel"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jordan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jordan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kuwait",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kuwait"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lebanon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lebanon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Libya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Libya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Morocco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Morocco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palestinian_territories",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palestinian_territories"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Oman",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Oman"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Qatar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Qatar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saudi_Arabia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saudi_Arabia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tunisia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tunisia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkey",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkey"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Yemen",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Yemen"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Aruba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Aruba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Christmas_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Christmas_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Curacao",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Curacao"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kosovo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kosovo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Syria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Syria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "is_a",
@@ -9262,813 +6927,327 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Kingdom",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Kingdom"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/American_Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/American_Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cook_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cook_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Fiji",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Fiji"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Polynesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Polynesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kiribati",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kiribati"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Marshall_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Marshall_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nauru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nauru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Caledonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Caledonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niue",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niue"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Solomon_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Solomon_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tokelau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tokelau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tonga",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tonga"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tuvalu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tuvalu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vanuatu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vanuatu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bangladesh",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bangladesh"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bhutan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bhutan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/India",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/India"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Maldives",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Maldives"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nepal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nepal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pakistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pakistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sri_Lanka",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sri_Lanka"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brunei",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brunei"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cambodia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cambodia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Indonesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Indonesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Laos",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Laos"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malaysia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malaysia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Myanmar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Myanmar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Philippines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Philippines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Thailand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Thailand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/East_Timor",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/East_Timor"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vietnam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vietnam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cameroon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cameroon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "is_a",
@@ -10076,863 +7255,347 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cape_Verde",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cape_Verde"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chad",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chad"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ethiopia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ethiopia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kenya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kenya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liberia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liberia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Madagascar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Madagascar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauretania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauretania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauritius",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauritius"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mayotte",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mayotte"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Namibia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Namibia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Senegal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Senegal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Seychelles",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Seychelles"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sierra_Leone",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sierra_Leone"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Somalia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Somalia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Africa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Africa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Helena",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Helena"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uganda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uganda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Angola",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Angola"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Benin",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Benin"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Botswana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Botswana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burkina_Faso",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burkina_Faso"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burundi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burundi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Central_African_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Central_African_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Comoros",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Comoros"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ivory_Coast",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ivory_Coast"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Djibouti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Djibouti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Eritrea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Eritrea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gabon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gabon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Gambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Gambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ghana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ghana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea_Bissau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea_Bissau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lesotho",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lesotho"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malawi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malawi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mali",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mali"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mozambique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mozambique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niger",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niger"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nigeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nigeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Rwanda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Rwanda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Swaziland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Swaziland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "is_a",
@@ -10940,13 +7603,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Togo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Togo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "is_a",
@@ -10954,13 +7611,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tanzania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tanzania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "is_a",
@@ -10968,33 +7619,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zimbabwe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zimbabwe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0551",
       "pred" : "is_a",
@@ -11213,397 +7846,163 @@
       "allValuesFromEdges" : [ {
         "sub" : "http://dbpedia.org/resource/Afghanistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Albania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Algeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/American_Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Andorra",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Angola",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Anguilla",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Argentina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Armenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Aruba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Australia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Austria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Azerbaijan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bahrain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bangladesh",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Barbados",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Belarus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belgium",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belize",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Benin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Bhutan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bolivia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Botswana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Brazil",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Brunei",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bulgaria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Burkina_Faso",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Burundi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cambodia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Cameroon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cape_Verde",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cayman_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Central_African_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Chad",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Channel_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Chile",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/China",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Christmas_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -11611,1853 +8010,767 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Colombia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Comoros",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cook_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Costa_Rica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Croatia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Cuba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Curacao",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Cyprus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Czech_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Djibouti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominican_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/East_Timor",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Ecuador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Egypt",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/El_Salvador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Eritrea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Estonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ethiopia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Falkland_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Fiji",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Finland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/France",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Guiana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Polynesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Gabon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Germany",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ghana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Gibraltar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Greece",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Grenada",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guadeloupe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Guatemala",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guyana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Haiti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Holy_See",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Honduras",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Hong_Kong",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Hungary",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Iceland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/India",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Indonesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iran",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iraq",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Isle_of_Man",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Israel",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Italy",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ivory_Coast",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Jamaica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Japan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Jordan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kazakhstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kenya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Kiribati",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kosovo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044"
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Kuwait",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Laos",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Latvia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lebanon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Lesotho",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liberia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Libya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liechtenstein",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lithuania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Luxembourg",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Macau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Madagascar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malawi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malaysia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Maldives",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Mali",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malta",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Marshall_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Martinique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauretania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauritius",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mayotte",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mexico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Moldova",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Monaco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Mongolia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Montenegro",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Montserrat",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Morocco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mozambique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Myanmar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Namibia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nauru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Nepal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Caledonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Zealand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Nicaragua",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Niger",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nigeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Niue",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norfolk_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/North_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053"
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Oman",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pakistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palestinian_territories",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Panama",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Paraguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Peru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Philippines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Poland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Portugal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Puerto_Rico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Qatar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Romania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Rwanda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Réunion",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Helena",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Lucia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Martin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/San_Marino",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Scotland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Senegal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Serbia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Seychelles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sierra_Leone",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Singapore",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sint_Maarten",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovakia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Solomon_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Somalia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Africa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037"
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Spain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sri_Lanka",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Suriname",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Swaziland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Switzerland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Syria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043"
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Taiwan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055"
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tajikistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tanzania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Thailand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Bahamas",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Gambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Togo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Tokelau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tonga",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tunisia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkey",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkmenistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tuvalu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Uganda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Ukraine",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Kingdom",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Uruguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Uzbekistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Vanuatu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Venezuela",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Vietnam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Western_Sahara",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Yemen",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Zambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Zimbabwe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -13465,260 +8778,118 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Georgia_(country)",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
+        "sub" : "http://purl.obolibrary.org/obo/NCIT_C25464",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/BFO_0000050",
       "allValuesFromEdges" : [ {
+        "sub" : "http://dbpedia.org/resource/Caribbean",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Central_America",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Melanesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Micronesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Middle_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Polynesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Scandinavia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-central_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/SouthAmerica",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/GEO_000000374",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Oceania"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/HANCESTRO_0301",

--- a/hancestro-base.obo
+++ b/hancestro-base.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: hancestro/releases/2023-10-13/hancestro-base.owl
+data-version: hancestro/releases/2024-01-24/hancestro-base.owl
 ontology: hancestro/hancestro-base
 property_value: http://purl.org/dc/elements/1.1/description "Human ancestry ontology for the NHGRI GWAS Catalog" xsd:string
 property_value: http://purl.org/dc/elements/1.1/title "Human Ancestry Ontology" xsd:string
@@ -7,106 +7,133 @@ property_value: http://purl.org/dc/elements/1.1/type IAO:8000001
 property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
 property_value: IAO:0000700 HANCESTRO:0004
 property_value: IAO:0000700 HANCESTRO:0304
-property_value: owl:versionInfo "2023-10-13" xsd:string
+property_value: owl:versionInfo "2024-01-24" xsd:string
 
 [Term]
 id: American:Samoa
 name: American Samoa
 xref: GAZ:00003957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: Burkina:Faso
 name: Burkina Faso
 xref: GAZ:00000905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: Cape:Verde
 name: Cape Verde
 xref: GAZ:00001227
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: Cayman:Islands
 name: Cayman Islands
 xref: GAZ:00003986
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
+
+[Term]
+id: Central:America
+name: Central America
+xref: GAZ:00002891
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: Channel:Islands
 name: Channel Islands
 xref: GAZ:00001539
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: Christmas:Island
 name: Christmas Island
 xref: GAZ:00005915
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located_in Australia/New Zealand
 
 [Term]
 id: Cook:Islands
 name: Cook Islands
 xref: GAZ:00053798
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: Costa:Rica
 name: Costa Rica
 xref: GAZ:00002901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: Czech:Republic
 name: Czech Republic
 xref: GAZ:00002954
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: Dominican:Republic
 name: Dominican Republic
 xref: GAZ:00003952
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: East:Timor
 name: East Timor
 synonym: "Timor-Leste" EXACT []
 xref: GAZ:00006913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
+
+[Term]
+id: Eastern:Africa
+name: Eastern Africa
+xref: GAZ:00000556
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Eastern:Asia
+name: Eastern Asia
+xref: GAZ:00002471
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Eastern:Europe
+name: Eastern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: El:Salvador
 name: El Salvador
 xref: GAZ:00002935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: Equatorial:Guinea
 name: Equatorial Guinea
 xref: GAZ:00001091
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: Faeroe:Islands
 name: Faeroe Islands
 xref: GAZ:00059206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 property_value: IAO:0000118 "Faroe Islands" xsd:string
 
 [Term]
@@ -114,63 +141,64 @@ id: Falkland:Islands
 name: Falkland Islands
 synonym: "Falkland Islands (Malvinas)" EXACT []
 xref: GAZ:00001412
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: French:Guiana
 name: French Guiana
 xref: GAZ:00002516
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: French:Polynesia
 name: French Polynesia
 xref: GAZ:00002918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
-id: GEO:000000374
+id: GAZ:00000013
 name: continent
-def: "One of the large, unbroken masses of land into which the Earth's surface is divided." []
 synonym: "major area" EXACT []
-xref: GAZ:00190836
 
 [Term]
 id: Georgia:(country)
 name: Georgia
 xref: GAZ:00004942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: Guinea:Bissau
 name: Guinea-Bissau
 xref: GAZ:00000910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: HANCESTRO:0002
 name: region
 def: "Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable." []
 synonym: "geographical area" EXACT []
-relationship: BFO:0000050 GEO:000000374 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of continent
+is_a: COB:0000032
+relationship: BFO:0000050 GAZ:00000013 {all_only="true"} ! part_of continent
 
 [Term]
 id: HANCESTRO:0003
-name: country
+name: obsolete country
 def: "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states." []
-relationship: RO:0001025 HANCESTRO:0002 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in region
 property_value: IAO:0000119 "NCIT:C25464" xsd:string
+is_obsolete: true
+replaced_by: http://purl.obolibrary.org/obo/NCIT_C25464
 
 [Term]
 id: HANCESTRO:0004
 name: ancestry category
 def: "Population category defined using ancestry informative markers (AIMs) based on genetic/genomic data" []
 synonym: "ancestral group" EXACT []
+is_a: OBI:0000181
 
 [Term]
 id: HANCESTRO:0005
@@ -316,174 +344,159 @@ is_a: HANCESTRO:0021 ! Chinese
 
 [Term]
 id: HANCESTRO:0029
-name: Africa
-xref: GAZ:00000457
-is_a: GEO:000000374 ! continent
-disjoint_from: HANCESTRO:0030 ! Asia
+name: obsolete Africa
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Africa
 
 [Term]
 id: HANCESTRO:0030
-name: Asia
-xref: GAZ:00000465
-is_a: GEO:000000374 ! continent
+name: obsolete Asia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Asia
 
 [Term]
 id: HANCESTRO:0031
-name: Europe
-xref: GAZ:00000464
-is_a: GEO:000000374 ! continent
+name: obsolete Europe
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Europe
 
 [Term]
 id: HANCESTRO:0032
-name: Oceania
-xref: GAZ:00000468
-is_a: GEO:000000374 ! continent
+name: obsolete Oceania
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Oceania
 
 [Term]
 id: HANCESTRO:0033
-name: Latin America and the Caribbean
-xref: GAZ:00000459
-is_a: GEO:000000374 ! continent
+name: obsolete Latin America and the Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
 
 [Term]
 id: HANCESTRO:0034
-name: Northern America
-xref: GAZ:00000458
-is_a: GEO:000000374 ! continent
+name: obsolete Northern America
+is_obsolete: true
+replaced_by: Northern:America
 
 [Term]
 id: HANCESTRO:0035
-name: Eastern Africa
-xref: GAZ:00000556
-is_a: HANCESTRO:0002 ! region
-disjoint_from: HANCESTRO:0036 ! Middle Africa
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Eastern Africa
+is_obsolete: true
+replaced_by: Eastern:Africa
 
 [Term]
 id: HANCESTRO:0036
-name: Middle Africa
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Middle Africa
+is_obsolete: true
+replaced_by: Middle:Africa
 
 [Term]
 id: HANCESTRO:0037
-name: Northern Africa
-xref: GAZ:00000555
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Northern Africa
+is_obsolete: true
+replaced_by: Northern:Africa
 
 [Term]
 id: HANCESTRO:0038
-name: Southern Africa
-xref: GAZ:00000553
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Southern Africa
+is_obsolete: true
+replaced_by: Southern:Africa
 
 [Term]
 id: HANCESTRO:0039
-name: Western Africa
-xref: GAZ:00000554
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Western Africa
+is_obsolete: true
+replaced_by: Western:Africa
 
 [Term]
 id: HANCESTRO:0041
-name: South-Central Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South Central Asia
+is_obsolete: true
+replaced_by: South-central:Asia
 
 [Term]
 id: HANCESTRO:0042
-name: South-Eastern Asia
-xref: GAZ:00000559
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South-Eastern Asia
+is_obsolete: true
+replaced_by: South-Eastern:Asia
 
 [Term]
 id: HANCESTRO:0043
-name: Western Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Western Asia
+is_obsolete: true
+replaced_by: Western:Asia
 
 [Term]
 id: HANCESTRO:0044
-name: Eastern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Eastern Europe
+is_obsolete: true
+replaced_by: Eastern:Europe
 
 [Term]
 id: HANCESTRO:0045
-name: Northern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Northern Europe
+is_obsolete: true
+replaced_by: Northern:Europe
 
 [Term]
 id: HANCESTRO:0046
-name: Southern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Southern Europe
+is_obsolete: true
+replaced_by: Southern:Europe
 
 [Term]
 id: HANCESTRO:0047
-name: Western Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Western Europe
+is_obsolete: true
+replaced_by: Western:Europe
 
 [Term]
 id: HANCESTRO:0048
-name: Caribbean
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Caribbean
 
 [Term]
 id: HANCESTRO:0049
-name: South America
-xref: GAZ:00000459
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete South America
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/SouthAmerica
 
 [Term]
 id: HANCESTRO:0050
-name: Central America
-xref: GAZ:00002891
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Central America
+is_obsolete: true
+replaced_by: Central:America
 
 [Term]
 id: HANCESTRO:0051
 name: Australia/New Zealand
 is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: HANCESTRO:0052
-name: Melanesia
-xref: GAZ:00005860
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Melanesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Melanesia
 
 [Term]
 id: HANCESTRO:0053
-name: Micronesia
-xref: GAZ:00005862
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Micronesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Micronesia
 
 [Term]
 id: HANCESTRO:0054
-name: Polynesia
-xref: GAZ:00005861
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Polynesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Polynesia
 
 [Term]
 id: HANCESTRO:0055
-name: Eastern Asia
-xref: GAZ:00002471
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Eastern Asia
+is_obsolete: true
+replaced_by: Eastern:Asia
 
 [Term]
 id: HANCESTRO:0286
@@ -493,15 +506,15 @@ is_a: HANCESTRO:0008 ! Asian
 
 [Term]
 id: HANCESTRO:0288
-name: Scandinavia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0045 {all_only="true"} ! part_of Northern Europe
+name: obsolete Scandinavia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Scandinavia
 
 [Term]
 id: HANCESTRO:0289
-name: South Asia
-xref: GAZ:00002472
-is_a: HANCESTRO:0002 ! region
+name: obsolete South Asia
+is_obsolete: true
+replaced_by: South:Asia
 
 [Term]
 id: HANCESTRO:0290
@@ -515,6 +528,7 @@ is_a: HANCESTRO:0004 ! ancestry category
 id: HANCESTRO:0304
 name: ancestry status
 def: "General characterisation of the ancestry of a population or individual" []
+is_a: BFO:0000019
 union_of: HANCESTRO:0305 ! genetically isolated ancestry
 union_of: HANCESTRO:0306 ! admixed ancestry
 
@@ -534,7 +548,7 @@ is_a: HANCESTRO:0304 ! ancestry status
 id: HANCESTRO:0307
 name: Italian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Italy
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy ! isDemonymOf Italy
 
 [Term]
 id: HANCESTRO:0309
@@ -620,7 +634,7 @@ is_a: HANCESTRO:0005 ! European
 id: HANCESTRO:0321
 name: Finnish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Finland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland ! isDemonymOf Finland
 
 [Term]
 id: HANCESTRO:0322
@@ -650,1322 +664,1322 @@ is_obsolete: true
 [Term]
 id: HANCESTRO:0331
 name: Sudanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sudan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan ! isDemonymOf Sudan
 
 [Term]
 id: HANCESTRO:0332
 name: Sahrawi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Western:Sahara {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Western Sahara
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Western:Sahara ! isDemonymOf Western Sahara
 
 [Term]
 id: HANCESTRO:0333
 name: Anguillan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Anguilla
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla ! isDemonymOf Anguilla
 
 [Term]
 id: HANCESTRO:0334
 name: Antiguan or Barbudan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Antigua and Barbuda
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda ! isDemonymOf Antigua and Barbuda
 
 [Term]
 id: HANCESTRO:0335
 name: Barbadian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Barbados
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados ! isDemonymOf Barbados
 
 [Term]
 id: HANCESTRO:0336
 name: Haitian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Haiti
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti ! isDemonymOf Haiti
 
 [Term]
 id: HANCESTRO:0337
 name: Jamaican
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jamaica
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica ! isDemonymOf Jamaica
 
 [Term]
 id: HANCESTRO:0338
 name: Tajikistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tajikistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan ! isDemonymOf Tajikistan
 
 [Term]
 id: HANCESTRO:0339
 name: Turkmen
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkmenistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan ! isDemonymOf Turkmenistan
 
 [Term]
 id: HANCESTRO:0340
 name: Uzbekistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uzbekistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan ! isDemonymOf Uzbekistan
 
 [Term]
 id: HANCESTRO:0341
 name: Afghan
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Afghanistan
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan ! isDemonymOf Afghanistan
 
 [Term]
 id: HANCESTRO:0342
 name: Kazakhstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kazakhstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan ! isDemonymOf Kazakhstan
 
 [Term]
 id: HANCESTRO:0343
 name: Kyrgyzstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kyrgyzstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan ! isDemonymOf Kyrgyzstan
 
 [Term]
 id: HANCESTRO:0344
 name: Albanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Albania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania ! isDemonymOf Albania
 
 [Term]
 id: HANCESTRO:0345
 name: Andorran
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Andorra
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra ! isDemonymOf Andorra
 
 [Term]
 id: HANCESTRO:0346
 name: Australian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Australia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia ! isDemonymOf Australia
 
 [Term]
 id: HANCESTRO:0347
 name: Austrian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Austria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria ! isDemonymOf Austria
 
 [Term]
 id: HANCESTRO:0348
 name: Belarusian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belarus
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus ! isDemonymOf Belarus
 
 [Term]
 id: HANCESTRO:0349
 name: Belgian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belgium
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium ! isDemonymOf Belgium
 
 [Term]
 id: HANCESTRO:0350
 name: Bermudian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bermuda
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda ! isDemonymOf Bermuda
 
 [Term]
 id: HANCESTRO:0351
 name: Bosnian or Herzegovinian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bosnia and Herzegovina
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina ! isDemonymOf Bosnia and Herzegovina
 
 [Term]
 id: HANCESTRO:0352
 name: Brazilian
 is_a: HANCESTRO:0014 ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brazil
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil ! isDemonymOf Brazil
 
 [Term]
 id: HANCESTRO:0353
 name: Bulgarian
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bulgaria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria ! isDemonymOf Bulgaria
 
 [Term]
 id: HANCESTRO:0354
 name: Canadian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Canada
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada ! isDemonymOf Canada
 
 [Term]
 id: HANCESTRO:0355
 name: Channel Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Channel:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Channel Islands
+relationship: HANCESTRO:0330 Channel:Islands ! isDemonymOf Channel Islands
 
 [Term]
 id: HANCESTRO:0356
 name: Chilean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chile
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile ! isDemonymOf Chile
 
 [Term]
 id: HANCESTRO:0357
 name: Croatian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Croatia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia ! isDemonymOf Croatia
 
 [Term]
 id: HANCESTRO:0358
 name: Czech
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Czech:Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Czech Republic
+relationship: HANCESTRO:0330 Czech:Republic ! isDemonymOf Czech Republic
 
 [Term]
 id: HANCESTRO:0359
 name: Danish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Denmark
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark ! isDemonymOf Denmark
 
 [Term]
 id: HANCESTRO:0360
 name: Estonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Estonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia ! isDemonymOf Estonia
 
 [Term]
 id: HANCESTRO:0361
 name: Faroese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Faeroe:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Faeroe Islands
+relationship: HANCESTRO:0330 Faeroe:Islands ! isDemonymOf Faeroe Islands
 
 [Term]
 id: HANCESTRO:0362
 name: Falkland Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Falkland:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Falkland Islands
+relationship: HANCESTRO:0330 Falkland:Islands ! isDemonymOf Falkland Islands
 
 [Term]
 id: HANCESTRO:0363
 name: French
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/France {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf France
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/France ! isDemonymOf France
 
 [Term]
 id: HANCESTRO:0364
 name: German
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Germany
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany ! isDemonymOf Germany
 
 [Term]
 id: HANCESTRO:0365
 name: Gibraltarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gibraltar
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar ! isDemonymOf Gibraltar
 
 [Term]
 id: HANCESTRO:0366
 name: Greek
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greece
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece ! isDemonymOf Greece
 
 [Term]
 id: HANCESTRO:0367
 name: Greenlander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greenland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland ! isDemonymOf Greenland
 
 [Term]
 id: HANCESTRO:0368
 name: Hungarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Hungary
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary ! isDemonymOf Hungary
 
 [Term]
 id: HANCESTRO:0369
 name: Icelandic
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iceland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland ! isDemonymOf Iceland
 
 [Term]
 id: HANCESTRO:0370
 name: Manx
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Isle of Man
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man ! isDemonymOf Isle of Man
 
 [Term]
 id: HANCESTRO:0371
 name: Latvian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Latvia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia ! isDemonymOf Latvia
 
 [Term]
 id: HANCESTRO:0372
 name: Liechtensteiner
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liechtenstein
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein ! isDemonymOf Liechtenstein
 
 [Term]
 id: HANCESTRO:0373
 name: Lithuanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lithuania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania ! isDemonymOf Lithuania
 
 [Term]
 id: HANCESTRO:0374
 name: Luxembourgish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Luxembourg
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg ! isDemonymOf Luxembourg
 
 [Term]
 id: HANCESTRO:0375
 name: Maltese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malta
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta ! isDemonymOf Malta
 
 [Term]
 id: HANCESTRO:0376
 name: Monegasque
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Monaco
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco ! isDemonymOf Monaco
 
 [Term]
 id: HANCESTRO:0377
 name: Montenegrin
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montenegro
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro ! isDemonymOf Montenegro
 
 [Term]
 id: HANCESTRO:0378
 name: New Zealandish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Zealand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Zealand
+relationship: HANCESTRO:0330 New:Zealand ! isDemonymOf New Zealand
 
 [Term]
 id: HANCESTRO:0379
 name: Norfolk Islander
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
+is_a: HANCESTRO:0018 ! uncategorised population
 relationship: HANCESTRO:0301 HANCESTRO:0305 {all_only="true"} ! hasAncestryStatus genetically isolated ancestry
-relationship: HANCESTRO:0330 Norfolk:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norfolk Island
+relationship: HANCESTRO:0330 Norfolk:Island ! isDemonymOf Norfolk Island
 
 [Term]
 id: HANCESTRO:0380
 name: Norwegian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norway
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway ! isDemonymOf Norway
 
 [Term]
 id: HANCESTRO:0381
 name: Polish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Poland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland ! isDemonymOf Poland
 
 [Term]
 id: HANCESTRO:0382
 name: Portugese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Portugal
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal ! isDemonymOf Portugal
 
 [Term]
 id: HANCESTRO:0383
 name: Irish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Ireland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland ! isDemonymOf Republic of Ireland
 
 [Term]
 id: HANCESTRO:0384
 name: Moldovan
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Moldova
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova ! isDemonymOf Moldova
 
 [Term]
 id: HANCESTRO:0385
 name: Romanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Romania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania ! isDemonymOf Romania
 
 [Term]
 id: HANCESTRO:0386
 name: Russian
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Russia
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia ! isDemonymOf Russia
 
 [Term]
 id: HANCESTRO:0387
 name: Saint-Pierrais or Miquelonnais
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Pierre and Miquelon
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon ! isDemonymOf Saint Pierre and Miquelon
 
 [Term]
 id: HANCESTRO:0388
 name: Sammarinese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 San:Marino {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf San Marino
+relationship: HANCESTRO:0330 San:Marino ! isDemonymOf San Marino
 
 [Term]
 id: HANCESTRO:0389
 name: Serb
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Serbia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia ! isDemonymOf Serbia
 
 [Term]
 id: HANCESTRO:0390
 name: Slovak
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovakia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia ! isDemonymOf Slovakia
 
 [Term]
 id: HANCESTRO:0391
 name: Slovene
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovenia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia ! isDemonymOf Slovenia
 
 [Term]
 id: HANCESTRO:0392
 name: Spanish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Spain
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain ! isDemonymOf Spain
 
 [Term]
 id: HANCESTRO:0393
 name: Swedish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sweden
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden ! isDemonymOf Sweden
 
 [Term]
 id: HANCESTRO:0394
 name: Swiss
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Switzerland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland ! isDemonymOf Switzerland
 
 [Term]
 id: HANCESTRO:0395
 name: Macedonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Macedonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia ! isDemonymOf Republic of Macedonia
 
 [Term]
 id: HANCESTRO:0396
 name: Ukrainian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ukraine
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine ! isDemonymOf Ukraine
 
 [Term]
 id: HANCESTRO:0397
 name: Argentine
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Argentina
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina ! isDemonymOf Argentina
 
 [Term]
 id: HANCESTRO:0398
 name: Bahamian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 The:Bahamas {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Bahamas
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 The:Bahamas ! isDemonymOf The Bahamas
 
 [Term]
 id: HANCESTRO:0399
 name: Belizean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belize
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize ! isDemonymOf Belize
 
 [Term]
 id: HANCESTRO:0400
 name: Bolivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bolivia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia ! isDemonymOf Bolivia
 
 [Term]
 id: HANCESTRO:0401
 name: British Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf British Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands ! isDemonymOf British Virgin Islands
 
 [Term]
 id: HANCESTRO:0402
 name: Caymanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cayman:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cayman Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cayman:Islands ! isDemonymOf Cayman Islands
 
 [Term]
 id: HANCESTRO:0403
 name: Colombian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Colombia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia ! isDemonymOf Colombia
 
 [Term]
 id: HANCESTRO:0404
 name: Costa Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Costa:Rica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Costa Rica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Costa:Rica ! isDemonymOf Costa Rica
 
 [Term]
 id: HANCESTRO:0405
 name: Cuban
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cuba
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba ! isDemonymOf Cuba
 
 [Term]
 id: HANCESTRO:0406
 name: Dominican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Dominica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica ! isDemonymOf Dominica
 
 [Term]
 id: HANCESTRO:0407
 name: Ecuadorian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ecuador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador ! isDemonymOf Ecuador
 
 [Term]
 id: HANCESTRO:0408
 name: Salvadoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 El:Salvador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf El Salvador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 El:Salvador ! isDemonymOf El Salvador
 
 [Term]
 id: HANCESTRO:0409
 name: French Guianese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Guiana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Guiana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Guiana ! isDemonymOf French Guiana
 
 [Term]
 id: HANCESTRO:0410
 name: Grenadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Grenada
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada ! isDemonymOf Grenada
 
 [Term]
 id: HANCESTRO:0411
 name: Guatemalan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guatemala
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala ! isDemonymOf Guatemala
 
 [Term]
 id: HANCESTRO:0412
 name: Guyanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guyana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana ! isDemonymOf Guyana
 
 [Term]
 id: HANCESTRO:0413
 name: Honduran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Honduras
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras ! isDemonymOf Honduras
 
 [Term]
 id: HANCESTRO:0414
 name: Martinican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Martinique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique ! isDemonymOf Martinique
 
 [Term]
 id: HANCESTRO:0415
 name: Mexican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mexico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico ! isDemonymOf Mexico
 
 [Term]
 id: HANCESTRO:0416
 name: Montserratian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montserrat
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat ! isDemonymOf Montserrat
 
 [Term]
 id: HANCESTRO:0417
 name: Nicaraguan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nicaragua
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua ! isDemonymOf Nicaragua
 
 [Term]
 id: HANCESTRO:0418
 name: Panamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Panama
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama ! isDemonymOf Panama
 
 [Term]
 id: HANCESTRO:0419
 name: Paraguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Paraguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay ! isDemonymOf Paraguay
 
 [Term]
 id: HANCESTRO:0420
 name: Peruvian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Peru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru ! isDemonymOf Peru
 
 [Term]
 id: HANCESTRO:0421
 name: Puerto Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Puerto:Rico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Puerto Rico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Puerto:Rico ! isDemonymOf Puerto Rico
 
 [Term]
 id: HANCESTRO:0422
 name: Kittitian or Nevisian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Kitts and Nevis
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis ! isDemonymOf Saint Kitts and Nevis
 
 [Term]
 id: HANCESTRO:0423
 name: Saint Lucian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Lucia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Lucia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Lucia ! isDemonymOf Saint Lucia
 
 [Term]
 id: HANCESTRO:0424
 name: Saint Vincentian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Vincent and the Grenadines
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines ! isDemonymOf Saint Vincent and the Grenadines
 
 [Term]
 id: HANCESTRO:0425
 name: Surinamese
 synonym: "Surinamer" EXACT []
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Suriname
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname ! isDemonymOf Suriname
 
 [Term]
 id: HANCESTRO:0426
 name: Trinidadian or Tobagonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Trinidad and Tobago
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago ! isDemonymOf Trinidad and Tobago
 
 [Term]
 id: HANCESTRO:0427
 name: Turks and Caicos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turks and Caicos Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands ! isDemonymOf Turks and Caicos Islands
 
 [Term]
 id: HANCESTRO:0428
 name: Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands ! isDemonymOf United States Virgin Islands
 
 [Term]
 id: HANCESTRO:0429
 name: Uruguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uruguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay ! isDemonymOf Uruguay
 
 [Term]
 id: HANCESTRO:0430
 name: Venezuelan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Venezuela
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela ! isDemonymOf Venezuela
 
 [Term]
 id: HANCESTRO:0431
 name: Algerian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Algeria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria ! isDemonymOf Algeria
 
 [Term]
 id: HANCESTRO:0432
 name: Armenian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Armenia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia ! isDemonymOf Armenia
 
 [Term]
 id: HANCESTRO:0433
 name: Azerbaijani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Azerbaijan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan ! isDemonymOf Azerbaijan
 
 [Term]
 id: HANCESTRO:0434
 name: Bahraini
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bahrain
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain ! isDemonymOf Bahrain
 
 [Term]
 id: HANCESTRO:0435
 name: Cypriote
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cyprus
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus ! isDemonymOf Cyprus
 
 [Term]
 id: HANCESTRO:0436
 name: Egyptian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Egypt
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt ! isDemonymOf Egypt
 
 [Term]
 id: HANCESTRO:0437
 name: Georgian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Georgia:(country) {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Georgia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Georgia:(country) ! isDemonymOf Georgia
 
 [Term]
 id: HANCESTRO:0438
 name: Iranian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iran
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran ! isDemonymOf Iran
 
 [Term]
 id: HANCESTRO:0439
 name: Iraqi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iraq
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq ! isDemonymOf Iraq
 
 [Term]
 id: HANCESTRO:0440
 name: Israeli
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Israel
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel ! isDemonymOf Israel
 
 [Term]
 id: HANCESTRO:0441
 name: Jordanian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jordan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan ! isDemonymOf Jordan
 
 [Term]
 id: HANCESTRO:0442
 name: Kuwaiti
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kuwait
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait ! isDemonymOf Kuwait
 
 [Term]
 id: HANCESTRO:0443
 name: Lebanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lebanon
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon ! isDemonymOf Lebanon
 
 [Term]
 id: HANCESTRO:0444
 name: Libyan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Libya
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya ! isDemonymOf Libya
 
 [Term]
 id: HANCESTRO:0445
 name: Moroccan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Morocco
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco ! isDemonymOf Morocco
 
 [Term]
 id: HANCESTRO:0446
 name: Palestinian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Palestinian:territories {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palestinian Territories
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Palestinian:territories ! isDemonymOf Palestinian Territories
 
 [Term]
 id: HANCESTRO:0447
 name: Omani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Oman
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman ! isDemonymOf Oman
 
 [Term]
 id: HANCESTRO:0448
 name: Qatari
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Qatar
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar ! isDemonymOf Qatar
 
 [Term]
 id: HANCESTRO:0449
 name: Saudi
 synonym: "Saudi Arab" EXACT []
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Saudi:Arabia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saudi Arabia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Saudi:Arabia ! isDemonymOf Saudi Arabia
 
 [Term]
 id: HANCESTRO:0450
 name: Tunisian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tunisia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia ! isDemonymOf Tunisia
 
 [Term]
 id: HANCESTRO:0451
 name: Turkish
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkey
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey ! isDemonymOf Turkey
 
 [Term]
 id: HANCESTRO:0452
 name: Emirati
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Arab Emirates
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates ! isDemonymOf United Arab Emirates
 
 [Term]
 id: HANCESTRO:0453
 name: Yemeni
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Yemen
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen ! isDemonymOf Yemen
 
 [Term]
 id: HANCESTRO:0454
 name: Aruban
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Aruba
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba ! isDemonymOf Aruba
 
 [Term]
 id: HANCESTRO:0455
 name: Christmas Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Christmas:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Christmas Island
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Christmas:Island ! isDemonymOf Christmas Island
 
 [Term]
 id: HANCESTRO:0456
 name: Cocos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cocos (Keeling) Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands ! isDemonymOf Cocos (Keeling) Islands
 
 [Term]
 id: HANCESTRO:0457
 name: Curacaoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Curacao
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao ! isDemonymOf Curacao
 
 [Term]
 id: HANCESTRO:0458
 name: Kosovar
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kosovo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo ! isDemonymOf Kosovo
 
 [Term]
 id: HANCESTRO:0459
 name: Northern Mariana Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Northern Mariana Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands ! isDemonymOf Northern Mariana Islands
 
 [Term]
 id: HANCESTRO:0460
 name: South Sudanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Sudan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Sudan ! isDemonymOf South Sudan
 
 [Term]
 id: HANCESTRO:0461
 name: Syrian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Syria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria ! isDemonymOf Syria
 
 [Term]
 id: HANCESTRO:0462
 name: British
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 United:Kingdom {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Kingdom
+relationship: HANCESTRO:0330 United:Kingdom ! isDemonymOf United Kingdom
 
 [Term]
 id: HANCESTRO:0463
 name: American
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 United:States {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 United:States ! isDemonymOf United States
 
 [Term]
 id: HANCESTRO:0464
 name: American Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 American:Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf American Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 American:Samoa ! isDemonymOf American Samoa
 
 [Term]
 id: HANCESTRO:0465
 name: Cook Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cook:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cook Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cook:Islands ! isDemonymOf Cook Islands
 
 [Term]
 id: HANCESTRO:0466
 name: Fijian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Fiji
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji ! isDemonymOf Fiji
 
 [Term]
 id: HANCESTRO:0467
 name: French Polynesian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Polynesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Polynesia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Polynesia ! isDemonymOf French Polynesia
 
 [Term]
 id: HANCESTRO:0468
 name: Guamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guam
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam ! isDemonymOf Guam
 
 [Term]
 id: HANCESTRO:0469
 name: I-Kiribati
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kiribati
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati ! isDemonymOf Kiribati
 
 [Term]
 id: HANCESTRO:0470
 name: Marshallese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Marshall:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Marshall Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Marshall:Islands ! isDemonymOf Marshall Islands
 
 [Term]
 id: HANCESTRO:0471
 name: Micronesian
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Micronesia (Federated States of)
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia ! isDemonymOf Micronesia (Federated States of)
 
 [Term]
 id: HANCESTRO:0472
 name: Nauruan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nauru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru ! isDemonymOf Nauru
 
 [Term]
 id: HANCESTRO:0473
 name: New Caledonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Caledonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Caledonia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 New:Caledonia ! isDemonymOf New Caledonia
 
 [Term]
 id: HANCESTRO:0474
 name: Niuean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niue
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue ! isDemonymOf Niue
 
 [Term]
 id: HANCESTRO:0475
 name: Palauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau ! isDemonymOf Palau
 
 [Term]
 id: HANCESTRO:0476
 name: Papua New Guinean
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Papua New Guinea
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea ! isDemonymOf Papua New Guinea
 
 [Term]
 id: HANCESTRO:0477
 name: Pitcairn Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Pitcairn:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pitcairn Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Pitcairn:Islands ! isDemonymOf Pitcairn Islands
 
 [Term]
 id: HANCESTRO:0478
 name: Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa ! isDemonymOf Samoa
 
 [Term]
 id: HANCESTRO:0479
 name: Solomon Islander
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 Solomon:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Solomon Islands
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 Solomon:Islands ! isDemonymOf Solomon Islands
 
 [Term]
 id: HANCESTRO:0480
 name: Tokelauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tokelau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau ! isDemonymOf Tokelau
 
 [Term]
 id: HANCESTRO:0481
 name: Tongan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tonga
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga ! isDemonymOf Tonga
 
 [Term]
 id: HANCESTRO:0482
 name: Tuvaluan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tuvalu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu ! isDemonymOf Tuvalu
 
 [Term]
 id: HANCESTRO:0483
 name: Ni-Vanuato
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vanuatu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu ! isDemonymOf Vanuatu
 
 [Term]
 id: HANCESTRO:0484
 name: Wallis and Futuna Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Wallis and Futuna
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna ! isDemonymOf Wallis and Futuna
 
 [Term]
 id: HANCESTRO:0485
 name: Bangladeshi
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bangladesh
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh ! isDemonymOf Bangladesh
 
 [Term]
 id: HANCESTRO:0486
 name: Bhutanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bhutan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan ! isDemonymOf Bhutan
 
 [Term]
 id: HANCESTRO:0487
 name: Indian
 synonym: "Asian Indian" EXACT []
 synonym: "Indian Asian" EXACT []
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/India {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf India
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/India ! isDemonymOf India
 
 [Term]
 id: HANCESTRO:0488
 name: Maldivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Maldives
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives ! isDemonymOf Maldives
 
 [Term]
 id: HANCESTRO:0489
 name: Nepalese
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nepal
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal ! isDemonymOf Nepal
 
 [Term]
 id: HANCESTRO:0490
 name: Pakistani
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pakistan
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan ! isDemonymOf Pakistan
 
 [Term]
 id: HANCESTRO:0491
 name: Sri Lankan
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 Sri:Lanka {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sri Lanka
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 Sri:Lanka ! isDemonymOf Sri Lanka
 
 [Term]
 id: HANCESTRO:0492
 name: Bruneian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brunei
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei ! isDemonymOf Brunei
 
 [Term]
 id: HANCESTRO:0493
 name: Cambodian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cambodia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia ! isDemonymOf Cambodia
 
 [Term]
 id: HANCESTRO:0494
 name: Indonesian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Indonesia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia ! isDemonymOf Indonesia
 
 [Term]
 id: HANCESTRO:0495
 name: Lao
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Laos
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos ! isDemonymOf Laos
 
 [Term]
 id: HANCESTRO:0496
 name: Malaysian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malaysia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia ! isDemonymOf Malaysia
 
 [Term]
 id: HANCESTRO:0497
 name: Burmese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Myanmar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar ! isDemonymOf Myanmar
 
 [Term]
 id: HANCESTRO:0498
 name: Filipino
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Philippines
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines ! isDemonymOf Philippines
 
 [Term]
 id: HANCESTRO:0500
 name: Thai
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Thailand
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand ! isDemonymOf Thailand
 
 [Term]
 id: HANCESTRO:0501
 name: Timorese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 East:Timor {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf East Timor
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 East:Timor ! isDemonymOf East Timor
 
 [Term]
 id: HANCESTRO:0502
 name: Vietnamese
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vietnam
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam ! isDemonymOf Vietnam
 
 [Term]
 id: HANCESTRO:0503
 name: Cameroonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cameroon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon ! isDemonymOf Cameroon
 
 [Term]
 id: HANCESTRO:0504
 name: Cape Verdean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Cape:Verde {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cape Verde
+relationship: HANCESTRO:0330 Cape:Verde ! isDemonymOf Cape Verde
 
 [Term]
 id: HANCESTRO:0505
 name: Chadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chad
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad ! isDemonymOf Chad
 
 [Term]
 id: HANCESTRO:0506
 name: Ethiopian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ethiopia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia ! isDemonymOf Ethiopia
 
 [Term]
 id: HANCESTRO:0507
 name: Kenyan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kenya
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya ! isDemonymOf Kenya
 
 [Term]
 id: HANCESTRO:0508
 name: Liberian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liberia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia ! isDemonymOf Liberia
 
 [Term]
 id: HANCESTRO:0509
 name: Malagasy
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Madagascar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar ! isDemonymOf Madagascar
 
 [Term]
 id: HANCESTRO:0510
 name: Mauritanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritania
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania ! isDemonymOf Mauritania
 
 [Term]
 id: HANCESTRO:0511
 name: Mauritian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritius
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius ! isDemonymOf Mauritius
 
 [Term]
 id: HANCESTRO:0512
 name: Mahoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mayotte
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte ! isDemonymOf Mayotte
 
 [Term]
 id: HANCESTRO:0513
 name: Namibian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Namibia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia ! isDemonymOf Namibia
 
 [Term]
 id: HANCESTRO:0514
 name: Sao Tomean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf São Tomé and Príncipe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe ! isDemonymOf São Tomé and Príncipe
 
 [Term]
 id: HANCESTRO:0515
 name: Senegalese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Senegal
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal ! isDemonymOf Senegal
 
 [Term]
 id: HANCESTRO:0516
 name: Seychellois
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Seychelles
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles ! isDemonymOf Seychelles
 
 [Term]
 id: HANCESTRO:0517
 name: Sierra Leonean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Sierra:Leone {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sierra Leone
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Sierra:Leone ! isDemonymOf Sierra Leone
 
 [Term]
 id: HANCESTRO:0518
 name: Somali
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Somalia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia ! isDemonymOf Somalia
 
 [Term]
 id: HANCESTRO:0519
 name: South African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Africa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Africa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Africa ! isDemonymOf South Africa
 
 [Term]
 id: HANCESTRO:0520
 name: St. Helenian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Helena {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Helena
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Helena ! isDemonymOf Saint Helena
 
 [Term]
 id: HANCESTRO:0521
 name: Ugandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uganda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda ! isDemonymOf Uganda
 
 [Term]
 id: HANCESTRO:0522
 name: Angolan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Angola
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola ! isDemonymOf Angola
 
 [Term]
 id: HANCESTRO:0523
 name: Beninese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Benin
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin ! isDemonymOf Benin
 
 [Term]
 id: HANCESTRO:0524
 name: Motswana
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Botswana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana ! isDemonymOf Botswana
 
 [Term]
 id: HANCESTRO:0525
 name: Burkinabe
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Burkina:Faso {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burkina Faso
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Burkina:Faso ! isDemonymOf Burkina Faso
 
 [Term]
 id: HANCESTRO:0526
 name: Burundian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burundi
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi ! isDemonymOf Burundi
 
 [Term]
 id: HANCESTRO:0527
 name: Central African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Central African Republic
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic ! isDemonymOf Central African Republic
 
 [Term]
 id: HANCESTRO:0528
 name: Comoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Comoros
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros ! isDemonymOf Comoros
 
 [Term]
 id: HANCESTRO:0529
 name: Congolese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Democratic Republic of the Congo
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of the Congo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo ! isDemonymOf Democratic Republic of the Congo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo ! isDemonymOf Republic of the Congo
 
 [Term]
 id: HANCESTRO:0530
 name: Ivoirian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Ivory:Coast {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Côte d'Ivoire
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Ivory:Coast ! isDemonymOf Côte d'Ivoire
 
 [Term]
 id: HANCESTRO:0531
 name: Djiboutian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Djibouti
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti ! isDemonymOf Djibouti
 
 [Term]
 id: HANCESTRO:0532
 name: Equatorial Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Equatorial:Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Equatorial Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Equatorial:Guinea ! isDemonymOf Equatorial Guinea
 
 [Term]
 id: HANCESTRO:0533
 name: Eritrean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Eritrea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea ! isDemonymOf Eritrea
 
 [Term]
 id: HANCESTRO:0534
 name: Gabonese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gabon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon ! isDemonymOf Gabon
 
 [Term]
 id: HANCESTRO:0535
 name: Gambian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 The:Gambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Gambia
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 The:Gambia ! isDemonymOf The Gambia
 
 [Term]
 id: HANCESTRO:0536
 name: Ghanaian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ghana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana ! isDemonymOf Ghana
 
 [Term]
 id: HANCESTRO:0537
 name: Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea ! isDemonymOf Guinea
 
 [Term]
 id: HANCESTRO:0538
 name: Bissau-Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Guinea:Bissau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea-Bissau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Guinea:Bissau ! isDemonymOf Guinea-Bissau
 
 [Term]
 id: HANCESTRO:0539
 name: Mosotho
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lesotho
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho ! isDemonymOf Lesotho
 
 [Term]
 id: HANCESTRO:0540
 name: Malawian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malawi
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi ! isDemonymOf Malawi
 
 [Term]
 id: HANCESTRO:0541
 name: Malian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mali
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali ! isDemonymOf Mali
 
 [Term]
 id: HANCESTRO:0542
 name: Mozambican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mozambique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique ! isDemonymOf Mozambique
 
 [Term]
 id: HANCESTRO:0543
 name: Nigerien
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niger
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger ! isDemonymOf Niger
 
 [Term]
 id: HANCESTRO:0544
 name: Nigerian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nigeria
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria ! isDemonymOf Nigeria
 
 [Term]
 id: HANCESTRO:0545
 name: Rwandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Rwanda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda ! isDemonymOf Rwanda
 
 [Term]
 id: HANCESTRO:0546
 name: Swazi
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Swaziland
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland ! isDemonymOf Swaziland
 
 [Term]
 id: HANCESTRO:0547
 name: Togolese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Togo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo ! isDemonymOf Togo
 
 [Term]
 id: HANCESTRO:0548
 name: Tanzanian
 is_a: HANCESTRO:0011 ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tanzania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania ! isDemonymOf Tanzania
 
 [Term]
 id: HANCESTRO:0549
 name: Zambian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zambia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia ! isDemonymOf Zambia
 
 [Term]
 id: HANCESTRO:0550
 name: Zimbabweian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zimbabwe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe ! isDemonymOf Zimbabwe
 
 [Term]
 id: HANCESTRO:0551
@@ -2262,91 +2276,121 @@ property_value: IAO:0000119 "PMID:31626772" xsd:string
 id: Holy:See
 name: Holy See
 xref: GAZ:00003103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: Hong:Kong
 name: Hong Kong
 synonym: "China, Hong Kong SAR" EXACT []
 xref: GAZ:00003203
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: Ivory:Coast
 name: Côte d'Ivoire
 synonym: "Ivory Coast" EXACT []
 xref: GAZ:00000906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: Marshall:Islands
 name: Marshall Islands
 xref: GAZ:00007161
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
+
+[Term]
+id: Middle:Africa
+name: Middle Africa
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: NCIT:C25464
+name: Country
+relationship: RO:0001025 HANCESTRO:0002 {all_only="true"} ! located_in region
 
 [Term]
 id: Netherlands:Antilles
 name: Netherlands Antilles
 xref: GAZ:00004019
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: New:Caledonia
 name: New Caledonia
 xref: GAZ:00005206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located_in Melanesia
 
 [Term]
 id: New:Zealand
 name: New Zealand
 xref: GAZ:00000469
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located_in Australia/New Zealand
 
 [Term]
 id: Norfolk:Island
 name: Norfolk Island
 xref: GAZ:00005913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located_in Australia/New Zealand
 
 [Term]
 id: North:Korea
 name: North Korea
 synonym: "Democratic People's Republic of Korea" EXACT []
 xref: GAZ:00002801
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
+
+[Term]
+id: Northern:Africa
+name: Northern Africa
+xref: GAZ:00000555
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Northern:America
+name: Northern America
+xref: GAZ:00000458
+is_a: GAZ:00000013 ! continent
+
+[Term]
+id: Northern:Europe
+name: Northern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Palestinian:territories
 name: Palestinian Territories
 synonym: "Occupied Palestinian Territory" EXACT []
 xref: GAZ:00002475
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: Pitcairn:Islands
 name: Pitcairn Islands
 synonym: "Pitcairn, Henderson, Ducie and Oeno Islands" EXACT []
 xref: GAZ:00005867
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 property_value: IAO:0000118 "Pitcairn" xsd:string
 
 [Term]
 id: Puerto:Rico
 name: Puerto Rico
 xref: GAZ:00006935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 property_value: IAO:0000118 "Commonwealth of Puerto Rico" xsd:string
 
 [Term]
@@ -2359,1487 +2403,1611 @@ id: Saint:Helena
 name: Saint Helena
 synonym: "St. Helena" EXACT []
 xref: GAZ:00000849
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: Saint:Lucia
 name: Saint Lucia
 xref: GAZ:00006909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: Saint:Martin
 name: Saint Martin
 xref: GAZ:00005841
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: San:Marino
 name: San Marino
 xref: GAZ:00003102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: Saudi:Arabia
 name: Saudi Arabia
 xref: GAZ:00005279
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: Sierra:Leone
 name: Sierra Leone
 xref: GAZ:00000914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: Sint:Maarten
 name: Sint Maarten
 xref: GAZ:00012579
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: Solomon:Islands
 name: Solomon Islands
 xref: GAZ:00005275
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located_in Melanesia
+
+[Term]
+id: South-Eastern:Asia
+name: South-Eastern Asia
+xref: GAZ:00000559
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: South-central:Asia
+name: South-Central Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Africa
 name: South Africa
 xref: GAZ:00000553
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located_in Southern Africa
+
+[Term]
+id: South:Asia
+name: South Asia
+xref: GAZ:00002472
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Korea
 name: South Korea
 synonym: "Republic of Korea" EXACT []
 xref: GAZ:00002802
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: South:Sudan
 name: South Sudan
 xref: GAZ:00233439
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
+
+[Term]
+id: Southern:Africa
+name: Southern Africa
+xref: GAZ:00000553
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Southern:Europe
+name: Southern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Sri:Lanka
 name: Sri Lanka
 xref: GAZ:00003924
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: The:Bahamas
 name: The Bahamas
 synonym: "Bahamas" EXACT []
 xref: GAZ:00002733
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: The:Gambia
 name: The Gambia
 synonym: "Gambia" EXACT []
 xref: GAZ:00000907
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: United:Kingdom
 name: United Kingdom
 synonym: "U.K." EXACT []
 xref: GAZ:00002637
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: United:States
 name: United States
 synonym: "United States of America" EXACT []
 xref: GAZ:00002459
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 property_value: IAO:0000118 "U.S." xsd:string
+
+[Term]
+id: Western:Africa
+name: Western Africa
+xref: GAZ:00000554
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Western:Asia
+name: Western Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Western:Europe
+name: Western Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Western:Sahara
 name: Western Sahara
 xref: GAZ:00000564
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Afghanistan
 name: Afghanistan
 xref: GAZ:00006882
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
+
+[Term]
+id: http://dbpedia.org/resource/Africa
+name: Africa
+xref: GAZ:00000457
+is_a: GAZ:00000013 ! continent
+disjoint_from: http://dbpedia.org/resource/Asia ! Asia
 
 [Term]
 id: http://dbpedia.org/resource/Albania
 name: Albania
 xref: GAZ:00002953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Algeria
 name: Algeria
 xref: GAZ:00000563
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Andorra
 name: Andorra
 xref: GAZ:00002948
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Angola
 name: Angola
 xref: GAZ:00001095
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Anguilla
 name: Anguilla
 xref: GAZ:00009159
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Antigua_and_Barbuda
 name: Antigua and Barbuda
 xref: GAZ:00006883
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Argentina
 name: Argentina
 xref: GAZ:00002928
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Armenia
 name: Armenia
 xref: GAZ:00004094
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Aruba
 name: Aruba
 xref: GAZ:00004025
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
+
+[Term]
+id: http://dbpedia.org/resource/Asia
+name: Asia
+xref: GAZ:00000465
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Australia
 name: Australia
 xref: GAZ:00000463
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located_in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Austria
 name: Austria
 xref: GAZ:00002942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Azerbaijan
 name: Azerbaijan
 xref: GAZ:00004941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bahrain
 name: Bahrain
 xref: GAZ:00005281
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bangladesh
 name: Bangladesh
 xref: GAZ:00003750
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Barbados
 name: Barbados
 xref: GAZ:00001251
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Belarus
 name: Belarus
 xref: GAZ:00006886
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belgium
 name: Belgium
 xref: GAZ:00002938
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belize
 name: Belize
 xref: GAZ:00002934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Benin
 name: Benin
 xref: GAZ:00000904
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Bermuda
 name: Bermuda
 xref: GAZ:00001264
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Bhutan
 name: Bhutan
 xref: GAZ:00003920
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bolivia
 name: Bolivia
 xref: GAZ:00002511
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Bosnia_and_Herzegovina
 name: Bosnia and Herzegovina
 xref: GAZ:00006887
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Botswana
 name: Botswana
 xref: GAZ:00001097
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located_in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Brazil
 name: Brazil
 xref: GAZ:00002828
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/British_Virgin_Islands
 name: British Virgin Islands
 xref: GAZ:00003961
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Brunei
 name: Brunei
 synonym: "Brunei Darussalam" EXACT []
 xref: GAZ:00003901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bulgaria
 name: Bulgaria
 xref: GAZ:00002950
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Burundi
 name: Burundi
 xref: GAZ:00001090
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Cambodia
 name: Cambodia
 xref: GAZ:00006888
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cameroon
 name: Cameroon
 xref: GAZ:00001093
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Canada
 name: Canada
 xref: GAZ:00002560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
+
+[Term]
+id: http://dbpedia.org/resource/Caribbean
+name: Caribbean
+is_a: HANCESTRO:0002 ! region
+disjoint_from: Central:America ! Central America
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Central_African_Republic
 name: Central African Republic
 xref: GAZ:00001089
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chad
 name: Chad
 xref: GAZ:00000586
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chile
 name: Chile
 xref: GAZ:00002825
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/China
 name: China
 xref: GAZ:00002845
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cocos_(Keeling)_Islands
 name: Cocos (Keeling) Islands
 xref: GAZ:00009721
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located_in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Colombia
 name: Colombia
 xref: GAZ:00002929
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Comoros
 name: Comoros
 xref: GAZ:00005820
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Croatia
 name: Croatia
 xref: GAZ:00002719
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Cuba
 name: Cuba
 xref: GAZ:00003762
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Curacao
 name: Curacao
 xref: GAZ:00012582
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Cyprus
 name: Cyprus
 xref: GAZ:00453362
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Democratic_Republic_of_the_Congo
 name: Democratic Republic of the Congo
 xref: GAZ:00001086
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Denmark
 name: Denmark
 xref: GAZ:00002635
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Djibouti
 name: Djibouti
 xref: GAZ:00000582
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Dominica
 name: Dominica
 xref: GAZ:00006890
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Ecuador
 name: Ecuador
 xref: GAZ:00002912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Egypt
 name: Egypt
 xref: GAZ:00003934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Eritrea
 name: Eritrea
 xref: GAZ:00000581
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Estonia
 name: Estonia
 xref: GAZ:00002959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ethiopia
 name: Ethiopia
 xref: GAZ:00000567
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Europe
+name: Europe
+xref: GAZ:00000464
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Federated_States_of_Micronesia
 name: Micronesia (Federated States of)
 xref: GAZ:00006897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Fiji
 name: Fiji
 xref: GAZ:00006891
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located_in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Finland
 name: Finland
 xref: GAZ:00002937
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/France
 name: France
 xref: GAZ:00002940
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Gabon
 name: Gabon
 xref: GAZ:00001092
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Germany
 name: Germany
 xref: GAZ:00002646
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ghana
 name: Ghana
 xref: GAZ:00000908
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Gibraltar
 name: Gibraltar
 xref: GAZ:00003987
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greece
 name: Greece
 xref: GAZ:00002945
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greenland
 name: Greenland
 xref: GAZ:00001507
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Grenada
 name: Grenada
 xref: GAZ:02000573
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guadeloupe
 name: Guadeloupe
 xref: GAZ:00067135
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guam
 name: Guam
 xref: GAZ:00006933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Guatemala
 name: Guatemala
 xref: GAZ:00002936
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Guinea
 name: Guinea
 xref: GAZ:00000909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Guyana
 name: Guyana
 xref: GAZ:00002522
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Haiti
 name: Haiti
 xref: GAZ:00003953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Honduras
 name: Honduras
 xref: GAZ:00002894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Hungary
 name: Hungary
 xref: GAZ:00002952
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Iceland
 name: Iceland
 xref: GAZ:00000843
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/India
 name: India
 xref: GAZ:00002839
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Indonesia
 name: Indonesia
 xref: GAZ:00003727
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iran
 name: Iran
 synonym: "Iran (Islamic Republic of)" EXACT []
 xref: GAZ:00004474
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iraq
 name: Iraq
 xref: GAZ:00004483
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Isle_of_Man
 name: Isle of Man
 xref: GAZ:00052477
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Israel
 name: Israel
 xref: GAZ:00002476
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Italy
 name: Italy
 xref: GAZ:00002650
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Jamaica
 name: Jamaica
 xref: GAZ:00003781
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Japan
 name: Japan
 xref: GAZ:00002747
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Jordan
 name: Jordan
 xref: GAZ:00002473
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kazakhstan
 name: Kazakhstan
 xref: GAZ:00004999
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kenya
 name: Kenya
 xref: GAZ:00001101
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Kiribati
 name: Kiribati
 xref: GAZ:00006894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Kosovo
 name: Kosovo
 xref: GAZ:00011337
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Kuwait
 name: Kuwait
 xref: GAZ:00005285
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kyrgyzstan
 name: Kyrgyzstan
 xref: GAZ:00006893
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Laos
 name: Laos
 synonym: "Lao People's Democratic Republic" EXACT []
 xref: GAZ:00006889
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
+
+[Term]
+id: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
+name: Latin America and the Caribbean
+xref: GAZ:00000459
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Latvia
 name: Latvia
 xref: GAZ:00002958
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lebanon
 name: Lebanon
 xref: GAZ:00002478
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Lesotho
 name: Lesotho
 xref: GAZ:00001098
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located_in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liberia
 name: Liberia
 xref: GAZ:00000911
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Libya
 name: Libya
 synonym: "Libyan Arab Jamahiriya" EXACT []
 xref: GAZ:00000566
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liechtenstein
 name: Liechtenstein
 xref: GAZ:00003858
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lithuania
 name: Lithuania
 xref: GAZ:00002960
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Luxembourg
 name: Luxembourg
 xref: GAZ:00002947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Macau
 name: Macau
 synonym: "China, Macao SAR" EXACT []
 xref: GAZ:00003202
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Madagascar
 name: Madagascar
 xref: GAZ:00001108
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malawi
 name: Malawi
 xref: GAZ:00001105
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malaysia
 name: Malaysia
 xref: GAZ:00003902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Maldives
 name: Maldives
 xref: GAZ:00006896
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Mali
 name: Mali
 xref: GAZ:00000584
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malta
 name: Malta
 xref: GAZ:00004017
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Martinique
 name: Martinique
 xref: GAZ:00003947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Mauretania
 name: Mauritania
 synonym: "Mauretania" EXACT []
 xref: GAZ:00000583
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mauritius
 name: Mauritius
 xref: GAZ:00003745
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mayotte
 name: Mayotte
 xref: GAZ:00003943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Melanesia
+name: Melanesia
+xref: GAZ:00005860
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Mexico
 name: Mexico
 xref: GAZ:00002852
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
+
+[Term]
+id: http://dbpedia.org/resource/Micronesia
+name: Micronesia
+xref: GAZ:00005862
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Moldova
 name: Moldova
 synonym: "Republic of Moldova" EXACT []
 xref: GAZ:00003897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Monaco
 name: Monaco
 xref: GAZ:00003857
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Mongolia
 name: Mongolia
 xref: GAZ:00008744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Montenegro
 name: Montenegro
 xref: GAZ:00006898
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Montserrat
 name: Montserrat
 xref: GAZ:00003988
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Morocco
 name: Morocco
 xref: GAZ:00000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mozambique
 name: Mozambique
 xref: GAZ:00001100
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Myanmar
 name: Myanmar
 synonym: "Burma" EXACT []
 xref: GAZ:00006899
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Namibia
 name: Namibia
 xref: GAZ:00001096
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located_in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nauru
 name: Nauru
 xref: GAZ:00006900
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Nepal
 name: Nepal
 xref: GAZ:00004399
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Netherlands
 name: Netherlands
 xref: GAZ:00001549
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Nicaragua
 name: Nicaragua
 xref: GAZ:00002978
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Niger
 name: Niger
 xref: GAZ:00000585
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nigeria
 name: Nigeria
 xref: GAZ:00000912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Niue
 name: Niue
 xref: GAZ:00006902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 property_value: IAO:0000118 "Niue Fekai" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Northern_Mariana_Islands
 name: Northern Mariana Islands
 xref: GAZ:00003958
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Norway
 name: Norway
 xref: GAZ:00002699
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 property_value: IAO:0000118 "Kingdom of Norway" xsd:string
+
+[Term]
+id: http://dbpedia.org/resource/Oceania
+name: Oceania
+xref: GAZ:00000468
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Oman
 name: Oman
 xref: GAZ:00005283
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Pakistan
 name: Pakistan
 xref: GAZ:00005246
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Palau
 name: Palau
 xref: GAZ:00006905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located_in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Panama
 name: Panama
 xref: GAZ:00002892
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located_in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Papua_New_Guinea
 name: Papua New Guinea
 xref: GAZ:00003922
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located_in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Paraguay
 name: Paraguay
 xref: GAZ:00002933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Peru
 name: Peru
 xref: GAZ:00002932
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Philippines
 name: Philippines
 xref: GAZ:00004525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 property_value: IAO:0000118 "The Philippines" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Poland
 name: Poland
 xref: GAZ:00002939
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
+
+[Term]
+id: http://dbpedia.org/resource/Polynesia
+name: Polynesia
+xref: GAZ:00005861
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Portugal
 name: Portugal
 xref: GAZ:00002944
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 property_value: IAO:0000118 "Portugese Republic" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Qatar
 name: Qatar
 xref: GAZ:00005286
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Ireland
 name: Republic of Ireland
 synonym: "Ireland" EXACT []
 xref: GAZ:00002943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Macedonia
 name: Republic of Macedonia
 synonym: "The former Yugoslav Republic of Macedonia" EXACT []
 xref: GAZ:00006895
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_the_Congo
 name: Republic of the Congo
 synonym: "Congo" EXACT []
 xref: GAZ:00001088
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Romania
 name: Romania
 xref: GAZ:00002951
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Russia
 name: Russia
 synonym: "Russian Federation" EXACT []
 xref: GAZ:00002721
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Rwanda
 name: Rwanda
 xref: GAZ:00001087
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Réunion
 name: Réunion
 xref: GAZ:00053746
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Kitts_and_Nevis
 name: Saint Kitts and Nevis
 xref: GAZ:00006906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Pierre_and_Miquelon
 name: Saint Pierre and Miquelon
 synonym: "Saint-Pierre-et-Miquelon" EXACT []
 xref: GAZ:00003942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines
 name: Saint Vincent and the Grenadines
 xref: GAZ:02000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Samoa
 name: Samoa
 xref: GAZ:00006910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
+
+[Term]
+id: http://dbpedia.org/resource/Scandinavia
+name: Scandinavia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: http://dbpedia.org/resource/Scotland
 name: Scotland
 xref: GAZ:00002639
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Senegal
 name: Senegal
 xref: GAZ:00000913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Serbia
 name: Serbia
 xref: GAZ:00002957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Seychelles
 name: Seychelles
 xref: GAZ:00005821
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Singapore
 name: Singapore
 xref: GAZ:00003923
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Slovakia
 name: Slovakia
 xref: GAZ:00002956
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Slovenia
 name: Slovenia
 xref: GAZ:00002955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Somalia
 name: Somalia
 xref: GAZ:00001104
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/SouthAmerica
+name: South America
+xref: GAZ:00000459
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Spain
 name: Spain
 xref: GAZ:00000591
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located_in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Sudan
 name: Sudan
 xref: GAZ:00000560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Suriname
 name: Suriname
 xref: GAZ:00002525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Swaziland
 name: Swaziland
 xref: GAZ:00001099
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located_in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Sweden
 name: Sweden
 xref: GAZ:00002729
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located_in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Switzerland
 name: Switzerland
 xref: GAZ:00002941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located_in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Syria
 name: Syria
 xref: GAZ:00002474
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/São_Tomé_and_Príncipe
 name: São Tomé and Príncipe
 xref: GAZ:00006927
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located_in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Taiwan
 name: Taiwan
 xref: GAZ:00005341
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true"} ! located_in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located_in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tajikistan
 name: Tajikistan
 xref: GAZ:00006912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tanzania
 name: Tanzania
 synonym: "United Republic of Tanzania" EXACT []
 xref: GAZ:00001103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Thailand
 name: Thailand
 xref: GAZ:00003744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Togo
 name: Togo
 xref: GAZ:00000915
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located_in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Tokelau
 name: Tokelau
 xref: GAZ:00006914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Tonga
 name: Tonga
 xref: GAZ:00006916
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Trinidad_and_Tobago
 name: Trinidad and Tobago
 xref: GAZ:00003767
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tunisia
 name: Tunisia
 xref: GAZ:00000562
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located_in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Turkey
 name: Turkey
 xref: GAZ:00000558
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turkmenistan
 name: Turkmenistan
 xref: GAZ:00005018
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turks_and_Caicos_Islands
 name: Turks and Caicos Islands
 xref: GAZ:00003955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tuvalu
 name: Tuvalu
 xref: GAZ:00009715
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Uganda
 name: Uganda
 xref: GAZ:00001102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Ukraine
 name: Ukraine
 xref: GAZ:00002724
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located_in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/United_Arab_Emirates
 name: United Arab Emirates
 xref: GAZ:00005282
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/United_States_Virgin_Islands
 name: United States Virgin Islands
 synonym: "U.S. Virgin Islands" EXACT []
 xref: GAZ:00003959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located_in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Uruguay
 name: Uruguay
 xref: GAZ:00002930
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Uzbekistan
 name: Uzbekistan
 xref: GAZ:00004979
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located_in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Vanuatu
 name: Vanuatu
 xref: GAZ:00006918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located_in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Venezuela
 name: Venezuela
 xref: GAZ:00002931
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located_in South America
 
 [Term]
 id: http://dbpedia.org/resource/Vietnam
 name: Vietnam
 xref: GAZ:00003756
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located_in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Wallis_and_Futuna
 name: Wallis and Futuna
 synonym: "Wallis and Futuna Islands" EXACT []
 xref: GAZ:00007191
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located_in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Yemen
 name: Yemen
 xref: GAZ:00005284
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located_in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Zambia
 name: Zambia
 xref: GAZ:00001107
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Zimbabwe
 name: Zimbabwe
 xref: GAZ:00001106
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located_in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located_in Eastern Africa
 
 [Typedef]
 id: BFO:0000050

--- a/hancestro-base.owl
+++ b/hancestro-base.owl
@@ -11,14 +11,14 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hancestro/hancestro-base.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro-base.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro-base.owl"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0004"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0304"/>
         <dc:description>Human ancestry ontology for the NHGRI GWAS Catalog</dc:description>
         <dc:title>Human Ancestry Ontology</dc:title>
         <dc:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
-        <owl:versionInfo>2023-10-13</owl:versionInfo>
+        <owl:versionInfo>2024-01-24</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -317,281 +317,181 @@
     <!-- http://dbpedia.org/resource/Afghanistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Afghanistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid2"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006882</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Afghanistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
+        <rdfs:label>Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Albania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Albania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid5"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Albania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid5">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid5"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Algeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Algeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid8"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000563</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Algeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid8">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid8"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/American_Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/American_Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid11"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">American Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid11">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid11"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Andorra -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Andorra">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid14"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002948</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Andorra</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid14">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid14"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Angola -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Angola">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid17"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001095</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Angola</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid17">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid17"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Anguilla -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Anguilla">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid20"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009159</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Anguilla</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid20">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid20"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Antigua_and_Barbuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Antigua_and_Barbuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid23"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006883</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Antigua and Barbuda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid23">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid23"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Argentina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Argentina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid26"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002928</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Argentina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid26">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid26"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Armenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Armenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid29"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004094</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Armenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid29">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid29"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Aruba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Aruba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004025</oboInOwl:hasDbXref>
@@ -600,826 +500,536 @@
     
 
 
+    <!-- http://dbpedia.org/resource/Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
+        <rdfs:label>Asia</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Australia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Australia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid33"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000463</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Australia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid33">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid33"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Austria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Austria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid36"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Austria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid36">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid36"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Azerbaijan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Azerbaijan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid39"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Azerbaijan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid39">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid39"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bahrain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bahrain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid42"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005281</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bahrain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid42">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid42"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bangladesh -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bangladesh">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid45"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003750</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bangladesh</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid45">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid45"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Barbados -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Barbados">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid48"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001251</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Barbados</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid48">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid48"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belarus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belarus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid51"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006886</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belarus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid51">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid51"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belgium -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belgium">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid54"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002938</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belgium</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid54">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid54"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belize -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belize">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid57"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belize</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid57">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid57"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Benin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Benin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid60"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000904</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Benin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid60">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid60"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bermuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bermuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001264</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bermuda</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bhutan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bhutan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid64"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003920</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bhutan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid64">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid64"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bolivia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bolivia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid67"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002511</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bolivia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid67">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid67"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bosnia_and_Herzegovina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bosnia_and_Herzegovina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid70"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006887</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bosnia and Herzegovina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid70">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid70"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Botswana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Botswana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid73"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001097</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Botswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid73">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid73"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brazil -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brazil">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid76"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002828</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Brazil</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid76">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid76"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/British_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/British_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid79"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003961</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">British Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid79">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid79"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brunei -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brunei">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid82"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003901</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Brunei Darussalam</oboInOwl:hasExactSynonym>
         <rdfs:label>Brunei</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid82">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid82"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bulgaria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bulgaria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid85"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002950</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bulgaria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid85">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid85"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burkina_Faso -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burkina_Faso">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid88"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burkina Faso</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid88">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid88"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burundi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burundi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid91"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001090</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burundi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid91">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid91"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cambodia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cambodia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid94"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006888</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cambodia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid94">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid94"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cameroon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cameroon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid97"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001093</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cameroon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid97">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid97"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Canada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Canada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00002560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Canada</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Canada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cape_Verde -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cape_Verde">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001227</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cape Verde</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid101">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid101"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Cayman_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cayman_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003986</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cayman Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid104">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid104"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Central_African_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Central_African_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid107"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001089</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Central African Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid107">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid107"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Central_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Central_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
+        <rdfs:label>Central America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Chad -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chad">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid110"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000586</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chad</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid110">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid110"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Channel_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Channel_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid113"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001539</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Channel Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid113">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid113"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Chile -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chile">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid116"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002825</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chile</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid116">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid116"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/China -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/China">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid119"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002845</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">China</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid119">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid119"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Christmas_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Christmas_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -1435,173 +1045,107 @@
     <!-- http://dbpedia.org/resource/Colombia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Colombia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid123"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002929</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Colombia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid123">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid123"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Comoros -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Comoros">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid126"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005820</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Comoros</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid126">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid126"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cook_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cook_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid129"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053798</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cook Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid129">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid129"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Costa_Rica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Costa_Rica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid132"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002901</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Costa Rica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid132">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid132"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Croatia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Croatia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid135"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002719</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Croatia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid135">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid135"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cuba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cuba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid138"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003762</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cuba</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid138">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid138"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Curacao -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Curacao">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012582</oboInOwl:hasDbXref>
@@ -1613,179 +1157,113 @@
     <!-- http://dbpedia.org/resource/Cyprus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cyprus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid142"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00453362</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cyprus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid142">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid142"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Czech_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Czech_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid145"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002954</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Czech Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid145">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid145"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Democratic_Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid148"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001086</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Democratic Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid148">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid148"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Denmark -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Denmark">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid152"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002635</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Denmark</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid152">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid152"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Djibouti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Djibouti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid155"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000582</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Djibouti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid155">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid155"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid158"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006890</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Dominica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid158">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid158"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominican_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominican_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003952</oboInOwl:hasDbXref>
@@ -1797,1329 +1275,852 @@
     <!-- http://dbpedia.org/resource/East_Timor -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/East_Timor">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid162"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006913</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Timor-Leste</oboInOwl:hasExactSynonym>
         <rdfs:label>East Timor</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid162">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid162"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Eastern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Ecuador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ecuador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid165"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ecuador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid165">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid165"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Egypt -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Egypt">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid168"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Egypt</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid168">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid168"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/El_Salvador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/El_Salvador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">El Salvador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid171">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid171"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Equatorial_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Equatorial_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid174"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001091</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Equatorial Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid174">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid174"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Eritrea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Eritrea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid177"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000581</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Eritrea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid177">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid177"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Estonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Estonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid180"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002959</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Estonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid180">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid180"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ethiopia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ethiopia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid183"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000567</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ethiopia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid183">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid183"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
+        <rdfs:label>Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Faeroe_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Faeroe_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid186"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Faroe Islands</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00059206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Faeroe Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid186">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid186"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Falkland_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Falkland_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid189"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001412</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Falkland Islands (Malvinas)</oboInOwl:hasExactSynonym>
         <rdfs:label>Falkland Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid189">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid189"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Federated_States_of_Micronesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Federated_States_of_Micronesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid192"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006897</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Micronesia (Federated States of)</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid192">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid192"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Fiji -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Fiji">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid195"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006891</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Fiji</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid195">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid195"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Finland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Finland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid198"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002937</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Finland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid198">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid198"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/France -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/France">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid201"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002940</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">France</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid201">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid201"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Guiana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Guiana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid204"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002516</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Guiana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid204">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid204"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Polynesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Polynesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid207"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Polynesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid207">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid207"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gabon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gabon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid210"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001092</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gabon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid210">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid210"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Germany -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Germany">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid213"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002646</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Germany</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid213">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid213"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ghana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ghana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid216"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000908</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ghana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid216">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid216"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gibraltar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gibraltar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid219"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003987</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gibraltar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid219">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid219"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greece -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greece">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid222"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002945</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greece</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid222">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid222"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greenland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greenland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001507</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greenland</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greenland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Grenada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Grenada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid226"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000573</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Grenada</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid226">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid226"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guadeloupe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guadeloupe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid229"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00067135</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guadeloupe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid229">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid229"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid232"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid232">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid232"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guatemala -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guatemala">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid235"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002936</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guatemala</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid235">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid235"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid238"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid238">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid238"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea_Bissau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea_Bissau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea-Bissau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid241">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid241"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guyana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guyana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid244"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002522</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guyana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid244">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid244"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Haiti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Haiti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid247"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Haiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid247">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid247"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Holy_See -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Holy_See">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid250"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003103</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Holy See</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid250">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid250"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Honduras -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Honduras">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid253"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Honduras</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid253">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid253"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hong_Kong -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hong_Kong">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid256"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003203</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Hong Kong SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Hong Kong</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid256">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid256"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hungary -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hungary">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid259"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002952</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Hungary</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid259">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid259"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iceland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iceland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid262"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000843</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iceland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid262">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid262"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/India -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/India">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid265"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002839</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">India</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid265">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid265"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Indonesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Indonesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid268"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003727</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Indonesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid268">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid268"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iran -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iran">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid271"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004474</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Iran (Islamic Republic of)</oboInOwl:hasExactSynonym>
         <rdfs:label>Iran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid271">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid271"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iraq -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iraq">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid274"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004483</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iraq</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid274">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid274"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Isle_of_Man -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Isle_of_Man">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid277"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00052477</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Isle of Man</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid277">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid277"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Israel -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Israel">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid280"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002476</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Israel</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid280">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid280"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Italy -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Italy">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid283"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002650</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Italy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid283">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid283"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ivory_Coast -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ivory_Coast">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid286"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000906</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ivory Coast</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Côte d&apos;Ivoire</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid286">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid286"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jamaica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jamaica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid289"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003781</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jamaica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid289">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid289"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Japan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Japan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid292"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002747</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Japan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid292">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid292"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jordan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jordan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid295"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002473</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jordan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid295">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid295"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kazakhstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kazakhstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid298"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004999</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kazakhstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid298">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid298"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kenya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kenya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid301"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001101</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kenya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid301">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid301"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kiribati -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kiribati">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid304"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid304">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid304"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kosovo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kosovo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00011337</oboInOwl:hasDbXref>
@@ -3131,1234 +2132,837 @@
     <!-- http://dbpedia.org/resource/Kuwait -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kuwait">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005285</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kuwait</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid308">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid308"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kyrgyzstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kyrgyzstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid311"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006893</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kyrgyzstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid311">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid311"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Laos -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Laos">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006889</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Lao People&apos;s Democratic Republic</oboInOwl:hasExactSynonym>
         <rdfs:label>Laos</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid314">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid314"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Latin_America_and_the_Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Latvia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Latvia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid317"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002958</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Latvia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid317">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid317"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lebanon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lebanon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid320"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002478</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lebanon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid320">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid320"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lesotho -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lesotho">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid323"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001098</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lesotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid323">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid323"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liberia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liberia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid326"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000911</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liberia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid326">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid326"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Libya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Libya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid329"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000566</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Libyan Arab Jamahiriya</oboInOwl:hasExactSynonym>
         <rdfs:label>Libya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid329">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid329"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liechtenstein -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liechtenstein">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid332"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003858</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liechtenstein</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid332">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid332"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lithuania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lithuania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid335"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002960</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lithuania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid335">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid335"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Luxembourg -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Luxembourg">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid338"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Luxembourg</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid338">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid338"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Macau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Macau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003202</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Macao SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Macau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid341">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid341"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Madagascar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Madagascar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid344"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001108</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Madagascar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid344">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid344"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malawi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malawi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001105</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid347">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid347"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malaysia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malaysia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid350"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malaysia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid350">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid350"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Maldives -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Maldives">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid353"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006896</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Maldives</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid353">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid353"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mali -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mali">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid356"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000584</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid356">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid356"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malta -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malta">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid359"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004017</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malta</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid359">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid359"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Marshall_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Marshall_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid362"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007161</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Marshall Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid362">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid362"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Martinique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Martinique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid365"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Martinique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid365">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid365"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauretania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauretania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid368"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000583</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Mauretania</oboInOwl:hasExactSynonym>
         <rdfs:label>Mauritania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid368">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid368"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauritius -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauritius">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid371"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003745</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mauritius</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid371">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid371"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mayotte -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mayotte">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid374"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003943</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mayotte</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid374">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid374"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Melanesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Melanesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
+        <rdfs:label>Melanesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Mexico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mexico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid377"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002852</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mexico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid377">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid377"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Micronesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Micronesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
+        <rdfs:label>Micronesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Middle_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Middle_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Middle Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Moldova -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Moldova">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid380"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003897</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Moldova</oboInOwl:hasExactSynonym>
         <rdfs:label>Moldova</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid380">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid380"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Monaco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Monaco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid383"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003857</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Monaco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid383">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid383"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mongolia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mongolia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid386"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00008744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mongolia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid386">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid386"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montenegro -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montenegro">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid389"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006898</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montenegro</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid389">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid389"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montserrat -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montserrat">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid392"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003988</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montserrat</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid392">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid392"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Morocco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Morocco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid395"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Morocco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid395">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid395"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mozambique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mozambique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid398"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001100</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mozambique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid398">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid398"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Myanmar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Myanmar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid401"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006899</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Burma</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Myanmar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid401">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid401"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Namibia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Namibia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid404"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001096</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Namibia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid404">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid404"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nauru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nauru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid407"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006900</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nauru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid407">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid407"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nepal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nepal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid410"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004399</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nepal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid410">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid410"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid413"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001549</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid413">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid413"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands_Antilles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands_Antilles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid416"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004019</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands Antilles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid416">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid416"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Caledonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Caledonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid419"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Caledonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid419">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid419"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Zealand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Zealand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid422"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000469</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid422">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid422"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nicaragua -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nicaragua">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid425"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002978</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nicaragua</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid425">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid425"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niger -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niger">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid428"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000585</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niger</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid428">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid428"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nigeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nigeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid431"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nigeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid431">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid431"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niue -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niue">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid434"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Niue Fekai</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niue</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid434">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid434"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Norfolk_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norfolk_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid437"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norfolk Island</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid437">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid437"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/North_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/North_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid440"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002801</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Democratic People&apos;s Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>North Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid440">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid440"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
+        <rdfs:label>Northern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
+        <rdfs:label>Northern America</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Northern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Northern_Mariana_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Mariana_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003958</oboInOwl:hasDbXref>
@@ -4370,711 +2974,462 @@
     <!-- http://dbpedia.org/resource/Norway -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norway">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid445"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Kingdom of Norway</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002699</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norway</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid445">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid445"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Oceania -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Oceania">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
+        <rdfs:label>Oceania</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Oman -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Oman">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005283</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Oman</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid448">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid448"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pakistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pakistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid451"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005246</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Pakistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid451">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid451"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid454"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Palau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid454">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid454"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palestinian_territories -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palestinian_territories">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid457"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002475</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Occupied Palestinian Territory</oboInOwl:hasExactSynonym>
         <rdfs:label>Palestinian Territories</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid457">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid457"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Panama -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Panama">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid460"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002892</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Panama</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid460">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid460"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Papua_New_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Papua_New_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid463"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003922</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Papua New Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid463">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid463"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Paraguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Paraguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid466"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Paraguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid466">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid466"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Peru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Peru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid469"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002932</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Peru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid469">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid469"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Philippines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Philippines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid472"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>The Philippines</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00004525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Philippines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid472">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid472"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pitcairn_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pitcairn_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid475"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118 xml:lang="en">Pitcairn</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00005867</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Pitcairn, Henderson, Ducie and Oeno Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>Pitcairn Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid475">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid475"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Poland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Poland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002939</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Poland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid478">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid478"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Polynesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Polynesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
+        <rdfs:label>Polynesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Portugal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Portugal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid481"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Portugese Republic</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002944</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Portugal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid481">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid481"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Puerto_Rico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Puerto_Rico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid484"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Commonwealth of Puerto Rico</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Puerto Rico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid484">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid484"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Qatar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Qatar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid487"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005286</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Qatar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid487">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid487"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Ireland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Ireland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid490"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002943</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ireland</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Republic of Ireland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid490">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid490"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Macedonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Macedonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid493"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006895</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">The former Yugoslav Republic of Macedonia</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of Macedonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid493">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid493"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid496"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001088</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Congo</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid496">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid496"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Romania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Romania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid499"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002951</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Romania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid499">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid499"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Russia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Russia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid502"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002721</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Russian Federation</oboInOwl:hasExactSynonym>
         <rdfs:label>Russia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid502">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:allValuesFrom>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid502"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Rwanda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Rwanda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid508"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001087</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Rwanda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid508">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid508"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Réunion -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Réunion">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid511"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053746</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Réunion</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid511">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid511"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Helena -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Helena">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid514"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000849</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">St. Helena</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Helena</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid514">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid514"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Kitts_and_Nevis -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Kitts_and_Nevis">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid517"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006906</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Kitts and Nevis</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid517">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid517"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Lucia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Lucia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid520"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Lucia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid520">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid520"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Martin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Martin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005841</oboInOwl:hasDbXref>
@@ -5086,136 +3441,101 @@
     <!-- http://dbpedia.org/resource/Saint_Pierre_and_Miquelon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00003942</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Saint-Pierre-et-Miquelon</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Pierre and Miquelon</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid525"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Vincent and the Grenadines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid525">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid525"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid528"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid528">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid528"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/San_Marino -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/San_Marino">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid531"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">San Marino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid531">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid531"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saudi_Arabia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saudi_Arabia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid534"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005279</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saudi Arabia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid534">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid534"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Scandinavia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Scandinavia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Scandinavia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Scotland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Scotland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002639</oboInOwl:hasDbXref>
@@ -5227,146 +3547,91 @@
     <!-- http://dbpedia.org/resource/Senegal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Senegal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid538"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Senegal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid538">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid538"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Serbia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Serbia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid541"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Serbia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid541">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid541"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Seychelles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Seychelles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid544"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005821</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Seychelles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid544">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid544"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sierra_Leone -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sierra_Leone">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid547"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sierra Leone</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid547">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid547"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Singapore -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Singapore">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid550"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003923</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Singapore</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid550">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid550"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sint_Maarten -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sint_Maarten">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012579</oboInOwl:hasDbXref>
@@ -5378,174 +3643,171 @@
     <!-- http://dbpedia.org/resource/Slovakia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovakia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid554"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002956</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovakia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid554">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid554"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Slovenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid557"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid557">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid557"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Solomon_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Solomon_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid560"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005275</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Solomon Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid560">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid560"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Somalia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Somalia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid563"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001104</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Somalia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid563">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid563"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
+        <rdfs:label>South-Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-central_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-central_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>South-Central Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/SouthAmerica -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/SouthAmerica">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>South America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Africa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Africa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid566"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">South Africa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid566">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
+        <rdfs:label>South Asia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid569"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002802</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>South Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid569">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid569"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/South_Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00233439</oboInOwl:hasDbXref>
@@ -5554,209 +3816,163 @@
     
 
 
+    <!-- http://dbpedia.org/resource/Southern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
+        <rdfs:label>Southern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Southern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Southern Europe</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Spain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Spain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid573"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000591</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Spain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid573">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid573"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sri_Lanka -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sri_Lanka">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid576"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003924</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sri Lanka</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid576">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid576"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid579"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid579">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid579"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Suriname -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Suriname">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Suriname</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid582">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid582"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Swaziland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Swaziland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid585"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001099</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Swaziland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid585">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid585"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sweden -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sweden">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid589"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002729</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sweden</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid589">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid589"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Switzerland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Switzerland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid592"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Switzerland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid592">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid592"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Syria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Syria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002474</oboInOwl:hasDbXref>
@@ -5768,38 +3984,27 @@
     <!-- http://dbpedia.org/resource/São_Tomé_and_Príncipe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/São_Tomé_and_Príncipe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid596"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006927</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">São Tomé and Príncipe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid596">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid596"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Taiwan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Taiwan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005341</oboInOwl:hasDbXref>
@@ -5811,814 +4016,535 @@
     <!-- http://dbpedia.org/resource/Tajikistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tajikistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid600"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tajikistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid600">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid600"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tanzania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tanzania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid603"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001103</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">United Republic of Tanzania</oboInOwl:hasExactSynonym>
         <rdfs:label>Tanzania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid603">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid603"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Thailand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Thailand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid606"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Thailand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid606">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid606"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Bahamas -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Bahamas">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid609"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002733</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Bahamas</oboInOwl:hasExactSynonym>
         <rdfs:label>The Bahamas</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid609">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid609"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Gambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Gambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid612"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000907</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Gambia</oboInOwl:hasExactSynonym>
         <rdfs:label>The Gambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid612">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid612"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Togo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Togo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid615"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000915</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Togo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid615">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid615"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tokelau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tokelau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tokelau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid618">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid618"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tonga -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tonga">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid621"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006916</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tonga</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid621">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid621"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Trinidad_and_Tobago -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Trinidad_and_Tobago">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid624"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003767</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Trinidad and Tobago</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid624">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid624"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tunisia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tunisia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid627"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000562</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tunisia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid627">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid627"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkey -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkey">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid630"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000558</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkey</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid630">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid630"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkmenistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkmenistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid633"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005018</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkmenistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid633">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid633"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turks_and_Caicos_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turks_and_Caicos_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid636"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turks and Caicos Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid636">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid636"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tuvalu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tuvalu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid639"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009715</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tuvalu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid639">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid639"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uganda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uganda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid642"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uganda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid642">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid642"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ukraine -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ukraine">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid645"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002724</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ukraine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid645">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid645"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Arab_Emirates -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Arab_Emirates">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid648"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005282</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">United Arab Emirates</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid648">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid648"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Kingdom -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Kingdom">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid651"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002637</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.K.</oboInOwl:hasExactSynonym>
         <rdfs:label>United Kingdom</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid651">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid651"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <obo:IAO_0000118 xml:lang="en">U.S.</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002459</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>United States of America</oboInOwl:hasExactSynonym>
         <rdfs:label>United States</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid655"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003959</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.S. Virgin Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>United States Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid655">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid655"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uruguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uruguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid658"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002930</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uruguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid658">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid658"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uzbekistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uzbekistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid661"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004979</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uzbekistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid661">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid661"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vanuatu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vanuatu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid664"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vanuatu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid664">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid664"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Venezuela -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Venezuela">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid667"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002931</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Venezuela</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid667">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid667"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vietnam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vietnam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid670"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003756</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vietnam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid670">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid670"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Wallis_and_Futuna -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Wallis_and_Futuna">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid673"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007191</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Wallis and Futuna Islands</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Wallis and Futuna</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid673">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid673"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
+        <rdfs:label>Western Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Western_Sahara -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Western_Sahara">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid676"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000564</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Western Sahara</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid676">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid676"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Yemen -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Yemen">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid679"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005284</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Yemen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid679">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid679"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid682"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001107</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid682">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid682"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zimbabwe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zimbabwe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid685"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001106</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zimbabwe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid685">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid685"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cocos_(Keeling)_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cocos_(Keeling)_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -6634,35 +4560,34 @@
     <!-- http://dbpedia.org/resource/Georgia_(country) -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Georgia_(country)">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid689"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Georgia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid689">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid689"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GEO_000000374 -->
+    <!-- http://purl.obolibrary.org/obo/BFO_0000019 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000374">
-        <obo:IAO_0000115>One of the large, unbroken masses of land into which the Earth&apos;s surface is divided.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>GAZ:00190836</oboInOwl:hasDbXref>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/COB_0000032 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000032"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GAZ_00000013 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000013">
         <oboInOwl:hasExactSynonym>major area</oboInOwl:hasExactSynonym>
         <rdfs:label>continent</rdfs:label>
     </owl:Class>
@@ -6672,51 +4597,36 @@
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0002">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:subClassOf rdf:nodeID="genid691"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000115>Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>geographical area</oboInOwl:hasExactSynonym>
         <rdfs:label>region</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid691">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid691"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0003">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <rdfs:subClassOf rdf:nodeID="genid693"/>
         <obo:IAO_0000115>A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states.</obo:IAO_0000115>
         <obo:IAO_0000119>NCIT:C25464</obo:IAO_0000119>
-        <rdfs:label>country</rdfs:label>
+        <obo:IAO_0100001>http://purl.obolibrary.org/obo/NCIT_C25464</obo:IAO_0100001>
+        <rdfs:label>obsolete country</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid693">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid693"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0004">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000181"/>
         <obo:IAO_0000115>Population category defined using ancestry informative markers (AIMs) based on genetic/genomic data</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>ancestral group</oboInOwl:hasExactSynonym>
         <rdfs:label>ancestry category</rdfs:label>
@@ -7011,9 +4921,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
-        <rdfs:label>Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Africa"/>
+        <rdfs:label>obsolete Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7021,9 +4931,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
-        <rdfs:label>Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Asia"/>
+        <rdfs:label>obsolete Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7031,9 +4941,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0031 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
-        <rdfs:label>Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Europe"/>
+        <rdfs:label>obsolete Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7041,9 +4951,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
-        <rdfs:label>Oceania</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Oceania"/>
+        <rdfs:label>obsolete Oceania</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7051,9 +4961,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0033 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+        <rdfs:label>obsolete Latin America and the Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7061,9 +4971,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0034 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
-        <rdfs:label>Northern America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_America"/>
+        <rdfs:label>obsolete Northern America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7071,319 +4981,150 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0035 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid705"/>
-        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+        <rdfs:label>obsolete Eastern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid705">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid705"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid707"/>
-        <rdfs:label>Middle Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+        <rdfs:label>obsolete Middle Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid707">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid707"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid709"/>
-        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
-        <rdfs:label>Northern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+        <rdfs:label>obsolete Northern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid709">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid709"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0038 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid711"/>
-        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
-        <rdfs:label>Southern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+        <rdfs:label>obsolete Southern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid711">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid711"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0039 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid713"/>
-        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
-        <rdfs:label>Western Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+        <rdfs:label>obsolete Western Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid713">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid713"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0041 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid715"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label>South-Central Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+        <rdfs:label>obsolete South Central Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid715">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid715"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0042 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid718"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
-        <rdfs:label>South-Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+        <rdfs:label>obsolete South-Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid718">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid718"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid721"/>
-        <rdfs:label>Western Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+        <rdfs:label>obsolete Western Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid721">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid721"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0044 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid723"/>
-        <rdfs:label>Eastern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+        <rdfs:label>obsolete Eastern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid723">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid723"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0045 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid725"/>
-        <rdfs:label>Northern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+        <rdfs:label>obsolete Northern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid725">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid725"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid727"/>
-        <rdfs:label>Southern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+        <rdfs:label>obsolete Southern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid727">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid727"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0047 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid729"/>
-        <rdfs:label>Western Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+        <rdfs:label>obsolete Western Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid729">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid729"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid731"/>
-        <rdfs:label>Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+        <rdfs:label>obsolete Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid731">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid731"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0049 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid733"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>South America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+        <rdfs:label>obsolete South America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid733">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid733"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid735"/>
-        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
-        <rdfs:label>Central America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Central_America"/>
+        <rdfs:label>obsolete Central America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid735">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid735"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7391,103 +5132,54 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid737"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label>Australia/New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid737">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid737"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0052 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid739"/>
-        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
-        <rdfs:label>Melanesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+        <rdfs:label>obsolete Melanesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid739">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid739"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0053 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid741"/>
-        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
-        <rdfs:label>Micronesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+        <rdfs:label>obsolete Micronesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid741">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid741"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid743"/>
-        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
-        <rdfs:label>Polynesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+        <rdfs:label>obsolete Polynesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid743">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid743"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid745"/>
-        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+        <rdfs:label>obsolete Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid745">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid745"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7504,14 +5196,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0288 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0288">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label xml:lang="en">Scandinavia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
+        <rdfs:label>obsolete Scandinavia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7519,9 +5206,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0289 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0289">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
-        <rdfs:label xml:lang="en">South Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South_Asia"/>
+        <rdfs:label>obsolete South Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7555,6 +5242,7 @@ from this region. This category includes individuals with known admixture of pri
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
         <obo:IAO_0000115>General characterisation of the ancestry of a population or individual</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ancestry status</rdfs:label>
     </owl:Class>
@@ -7585,19 +5273,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0307">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid752"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Italian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid752">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0307"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid752"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7823,19 +5506,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0321">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid772"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Finnish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid772">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0321"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid772"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7909,25 +5587,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0331">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid780"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid780">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid780"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7935,25 +5602,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0332">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid783"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sahrawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid783">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid783"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7961,25 +5617,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0333">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid786"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Anguillan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid786">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid786"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -7987,25 +5632,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid789"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Antiguan or Barbudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid789">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid789"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8013,25 +5647,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0335">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid792"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Barbadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid792">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid792"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8039,25 +5662,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0336">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid795"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Haitian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid795">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid795"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8065,25 +5677,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid798"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jamaican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid798">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid798"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8091,25 +5692,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0338">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid801"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tajikistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid801">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid801"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8117,25 +5707,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid804"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkmen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid804">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid804"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8143,25 +5722,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid807"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uzbekistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid807">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid807"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8169,19 +5737,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0341">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid809"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Afghan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid809">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0341"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid809"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8189,25 +5752,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0342">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid812"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kazakhstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid812">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid812"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8215,25 +5767,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid815"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kyrgyzstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid815">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid815"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8241,19 +5782,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0344">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid817"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Albanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid817">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0344"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid817"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8261,19 +5797,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0345">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid819"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Andorran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid819">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0345"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid819"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8281,19 +5812,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0346">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid821"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Australian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid821">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0346"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid821"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8301,19 +5827,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0347">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid823"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Austrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid823">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0347"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid823"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8321,19 +5842,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0348">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid825"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belarusian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid825">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0348"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid825"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8341,19 +5857,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid827"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid827">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0349"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid827"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8361,19 +5872,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0350">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid829"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bermudian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid829">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0350"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid829"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8381,19 +5887,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0351">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid831"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bosnian or Herzegovinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid831">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0351"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid831"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8401,19 +5902,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid833"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Brazilian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid833">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0352"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid833"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8421,19 +5917,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid835"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bulgarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid835">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0353"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid835"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8441,19 +5932,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0354">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid837"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Canadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid837">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0354"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid837"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8461,19 +5947,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0355">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid839"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Channel Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid839">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0355"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid839"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8481,19 +5962,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0356">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid841"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chilean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid841">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0356"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid841"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8501,19 +5977,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0357">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid843"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Croatian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid843">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0357"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid843"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8521,19 +5992,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0358">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid845"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Czech</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid845">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0358"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid845"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8541,19 +6007,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0359">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid847"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Danish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid847">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0359"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid847"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8561,19 +6022,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0360">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid849"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Estonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid849">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0360"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid849"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8581,19 +6037,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0361">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid851"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Faroese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid851">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0361"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid851"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8601,19 +6052,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0362">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid853"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Falkland Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid853">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0362"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid853"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8621,19 +6067,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0363">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid855"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid855">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0363"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid855"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8641,19 +6082,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0364">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid857"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">German</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid857">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0364"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid857"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8661,19 +6097,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0365">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid859"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gibraltarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid859">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0365"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid859"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8681,19 +6112,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid861"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greek</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid861">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0366"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid861"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8701,19 +6127,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0367">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid863"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greenlander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid863">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0367"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid863"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8721,19 +6142,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0368">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid865"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Hungarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid865">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0368"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid865"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8741,19 +6157,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0369">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid867"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Icelandic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid867">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0369"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid867"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8761,19 +6172,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0370">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid869"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Manx</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid869">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0370"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid869"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8781,19 +6187,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0371">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid871"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Latvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid871">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0371"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid871"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8801,19 +6202,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0372">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid873"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liechtensteiner</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid873">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0372"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid873"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8821,19 +6217,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0373">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid875"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lithuanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid875">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0373"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid875"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8841,19 +6232,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid877"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Luxembourgish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid877">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0374"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid877"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8861,19 +6247,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0375">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid879"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maltese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid879">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0375"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid879"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8881,19 +6262,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0376">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid881"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Monegasque</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid881">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0376"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid881"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8901,19 +6277,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0377">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid883"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montenegrin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid883">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0377"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid883"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8921,19 +6292,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0378">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid885"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Zealandish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid885">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0378"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid885"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8941,7 +6307,12 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0379">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid888"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0301"/>
@@ -8963,22 +6334,6 @@ from this region. This category includes individuals with known admixture of pri
         </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norfolk Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid888">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid888"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -8986,19 +6341,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0380">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid895"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norwegian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid895">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0380"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid895"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9006,19 +6356,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0381">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid897"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Polish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid897">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0381"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid897"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9026,19 +6371,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0382">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid899"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Portugese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid899">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0382"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid899"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9046,19 +6386,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0383">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid901"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Irish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid901">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0383"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid901"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9066,19 +6401,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0384">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid903"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moldovan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid903">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0384"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid903"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9086,19 +6416,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0385">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid905"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Romanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid905">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0385"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid905"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9106,25 +6431,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid908"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Russian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid908">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid908"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9132,19 +6446,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0387">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid910"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint-Pierrais or Miquelonnais</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid910">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0387"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid910"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9152,19 +6461,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0388">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid912"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sammarinese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid912">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0388"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid912"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9172,19 +6476,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0389">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid914"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Serb</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid914">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0389"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid914"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9192,19 +6491,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0390">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid916"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovak</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid916">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0390"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid916"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9212,19 +6506,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0391">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid918"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovene</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid918">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0391"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid918"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9232,19 +6521,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0392">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid920"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Spanish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid920">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0392"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid920"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9252,19 +6536,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0393">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid922"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swedish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid922">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0393"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid922"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9272,19 +6551,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0394">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid924"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swiss</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid924">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0394"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid924"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9292,19 +6566,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid926"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Macedonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid926">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0395"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid926"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9312,19 +6581,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid928"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ukrainian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid928">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0396"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid928"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9332,25 +6596,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid931"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Argentine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid931">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid931"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9358,25 +6611,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0398">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid934"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahamian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid934">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid934"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9384,25 +6626,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid937"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belizean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid937">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid937"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9410,25 +6641,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid940"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bolivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid940">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid940"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9436,25 +6656,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0401">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid943"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid943">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid943"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9462,25 +6671,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid946"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Caymanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid946">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid946"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9488,25 +6686,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0403">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid949"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Colombian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid949">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid949"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9514,25 +6701,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0404">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid952"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Costa Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid952">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid952"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9540,25 +6716,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0405">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid955"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cuban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid955">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid955"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9566,25 +6731,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0406">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid958"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Dominican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid958">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid958"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9592,25 +6746,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0407">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid961"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ecuadorian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid961">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid961"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9618,25 +6761,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0408">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid964"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Salvadoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid964">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid964"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9644,25 +6776,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0409">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid967"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Guianese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid967">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid967"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9670,25 +6791,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0410">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid970"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Grenadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid970">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid970"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9696,25 +6806,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0411">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid973"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guatemalan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid973">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid973"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9722,25 +6821,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0412">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid976"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guyanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid976">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid976"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9748,25 +6836,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0413">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid979"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Honduran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid979">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid979"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9774,25 +6851,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0414">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid982"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Martinican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid982">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid982"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9800,25 +6866,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0415">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid985"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mexican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid985">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid985"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9826,25 +6881,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0416">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid988"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montserratian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid988">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid988"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9852,25 +6896,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0417">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid991"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nicaraguan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid991">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid991"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9878,25 +6911,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0418">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid994"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Panamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid994">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid994"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9904,25 +6926,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0419">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid997"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Paraguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid997">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid997"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9930,25 +6941,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1000"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Peruvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1000">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1000"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9956,25 +6956,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0421">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1003"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Puerto Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1003">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9982,25 +6971,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1006"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kittitian or Nevisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1006">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10008,25 +6986,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0423">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1009"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Lucian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1009">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1009"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10034,25 +7001,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0424">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1012"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Vincentian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1012">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1012"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10060,26 +7016,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0425">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1015"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Surinamer</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Surinamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1015">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10087,25 +7032,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0426">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1018"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Trinidadian or Tobagonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1018">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10113,25 +7047,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0427">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1021"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turks and Caicos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1021">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1021"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10139,25 +7062,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0428">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1024"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1024">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1024"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10165,25 +7077,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0429">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uruguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1027">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1027"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10191,25 +7092,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0430">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1030"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Venezuelan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1030">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1030"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10217,25 +7107,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0431">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1033"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Algerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1033">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1033"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10243,25 +7122,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1036"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Armenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1036">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1036"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10269,25 +7137,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0433">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1039"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Azerbaijani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1039">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1039"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10295,25 +7152,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0434">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1042"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahraini</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1042">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1042"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10321,25 +7167,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0435">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1045"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cypriote</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1045">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1045"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10347,25 +7182,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0436">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1048"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Egyptian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1048">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1048"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10373,25 +7197,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0437">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1051"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Georgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1051">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1051"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10399,25 +7212,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0438">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1054"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iranian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1054">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1054"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10425,25 +7227,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0439">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1057"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iraqi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1057">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1057"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10451,25 +7242,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0440">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1060"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Israeli</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1060">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1060"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10477,25 +7257,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0441">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1063"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jordanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1063">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1063"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10503,25 +7272,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1066"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kuwaiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1066">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1066"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10529,25 +7287,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1069"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lebanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1069">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1069"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10555,25 +7302,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0444">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1072"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Libyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1072">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1072"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10581,25 +7317,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0445">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1075"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moroccan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1075">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1075"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10607,25 +7332,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0446">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1078"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palestinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1078">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1078"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10633,25 +7347,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0447">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1081"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Omani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1081">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1081"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10659,25 +7362,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0448">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1084"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Qatari</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1084">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1084"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10685,26 +7377,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0449">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1087"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Saudi Arab</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Saudi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1087">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1087"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10712,25 +7393,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0450">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1090"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tunisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1090">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1090"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10738,25 +7408,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0451">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1093"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1093">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1093"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10764,25 +7423,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0452">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1096"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Emirati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1096">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1096"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10790,25 +7438,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0453">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1099"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Yemeni</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1099">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1099"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10816,25 +7453,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0454">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1102"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Aruban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1102">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1102"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10842,25 +7468,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0455">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1105"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Christmas Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1105">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1105"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10868,25 +7483,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0456">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1108"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cocos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1108">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1108"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10894,25 +7498,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0457">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1111"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Curacaoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1111">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1111"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10920,25 +7513,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0458">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1114"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kosovar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1114">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1114"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10946,25 +7528,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0459">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1117"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Northern Mariana Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1117">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1117"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10972,25 +7543,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0460">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1120"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1120">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1120"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10998,25 +7558,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0461">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1123"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Syrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1123">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1123"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11024,19 +7573,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0462">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1125"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1125">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0462"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1125"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11044,25 +7588,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1128"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1128">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1128"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11070,25 +7603,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0464">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1131"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1131">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1131"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11096,25 +7618,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0465">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1134"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cook Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1134">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1134"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11122,25 +7633,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1137"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Fijian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1137">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1137"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11148,25 +7648,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0467">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1140"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Polynesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1140">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1140"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11174,25 +7663,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1143"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1143">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1143"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11200,25 +7678,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1146"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">I-Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1146">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1146"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11226,25 +7693,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0470">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1149"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Marshallese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1149">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1149"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11252,25 +7708,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1152"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Micronesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1152">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1152"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11278,25 +7723,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0472">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1155"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nauruan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1155">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1155"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11304,25 +7738,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0473">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1158"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Caledonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1158">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1158"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11330,25 +7753,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0474">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1161"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Niuean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1161">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1161"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11356,25 +7768,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0475">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1164"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1164">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1164"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11382,25 +7783,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1167"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Papua New Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1167">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1167"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11408,25 +7798,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0477">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1170"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pitcairn Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1170">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1170"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11434,25 +7813,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0478">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1173"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1173">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1173"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11460,25 +7828,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1176"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Solomon Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1176">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1176"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11486,25 +7843,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0480">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1179"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tokelauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1179">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1179"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11512,25 +7858,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0481">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1182"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tongan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1182">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1182"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11538,25 +7873,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0482">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1185"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tuvaluan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1185">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1185"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11564,25 +7888,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0483">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1188"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ni-Vanuato</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1188">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1188"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11590,25 +7903,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1191"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Wallis and Futuna Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1191">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1191"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11616,25 +7918,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1194"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bangladeshi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1194">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1194"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11642,25 +7933,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1197"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bhutanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1197">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1197"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11668,27 +7948,16 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0487">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1200"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Asian Indian</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Indian Asian</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Indian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1200">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1200"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11696,25 +7965,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0488">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1203"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maldivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1203">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1203"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11722,25 +7980,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0489">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1206"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nepalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1206">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1206"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11748,25 +7995,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0490">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1209"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pakistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1209">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1209"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11774,25 +8010,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0491">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1212"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sri Lankan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1212">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1212"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11800,25 +8025,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0492">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1215"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bruneian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1215">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1215"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11826,25 +8040,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0493">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1218"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cambodian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1218">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1218"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11852,25 +8055,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1221"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Indonesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1221">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1221"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11878,25 +8070,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1224"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lao</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1224">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1224"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11904,25 +8085,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0496">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1227"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malaysian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1227">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1227"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11930,25 +8100,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0497">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1230"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burmese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1230">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1230"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11956,25 +8115,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0498">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1233"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Filipino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1233">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1233"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11982,25 +8130,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1236"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Thai</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1236">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1236"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12008,25 +8145,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1239"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Timorese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1239">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1239"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12034,25 +8160,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1242"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Vietnamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1242">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1242"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12060,25 +8175,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1245"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cameroonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1245">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1245"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12086,19 +8190,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1247"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cape Verdean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1247">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0504"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1247"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12106,25 +8205,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0505">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1250"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1250">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1250"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12132,25 +8220,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0506">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1253"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ethiopian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1253">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1253"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12158,25 +8235,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1256"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kenyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1256">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1256"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12184,25 +8250,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1259"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liberian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1259">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1259"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12210,25 +8265,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0509">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1262"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malagasy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1262">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1262"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12236,25 +8280,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0510">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1265"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1265">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1265"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12262,25 +8295,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0511">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1268"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1268">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1268"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12288,25 +8310,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0512">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1271"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mahoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1271">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1271"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12314,25 +8325,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0513">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1274"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Namibian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1274">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1274"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12340,25 +8340,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1277"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sao Tomean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1277">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1277"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12366,25 +8355,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0515">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1280"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Senegalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1280">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1280"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12392,25 +8370,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0516">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1283"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Seychellois</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1283">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1283"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12418,25 +8385,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1286"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sierra Leonean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1286">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1286"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12444,25 +8400,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0518">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1289"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Somali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1289">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1289"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12470,25 +8415,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0519">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1292"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1292">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1292"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12496,25 +8430,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0520">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1295"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">St. Helenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1295">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1295"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12522,25 +8445,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0521">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1298"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ugandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1298">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1298"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12548,25 +8460,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0522">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1301"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Angolan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1301">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1301"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12574,25 +8475,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0523">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1304"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Beninese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1304">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1304"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12600,25 +8490,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0524">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1307"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Motswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1307">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1307"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12626,25 +8505,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0525">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1310"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burkinabe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1310">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1310"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12652,25 +8520,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0526">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1313"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burundian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1313">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1313"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12678,25 +8535,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0527">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1316"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Central African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1316">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1316"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12704,25 +8550,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0528">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1319"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Comoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1319">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1319"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12730,36 +8565,20 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0529">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1322"/>
-        <rdfs:subClassOf rdf:nodeID="genid1324"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Congolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1322">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Restriction rdf:nodeID="genid1324">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1322"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1324"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12767,25 +8586,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1327"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ivoirian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1327">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1327"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12793,25 +8601,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0531">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1330"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Djiboutian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1330">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1330"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12819,25 +8616,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0532">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1333"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Equatorial Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1333">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1333"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12845,25 +8631,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0533">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1336"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Eritrean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1336">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1336"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12871,25 +8646,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0534">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1339"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gabonese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1339">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1339"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12897,25 +8661,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0535">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1342"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1342">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1342"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12923,25 +8676,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0536">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1345"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ghanaian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1345">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1345"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12949,25 +8691,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0537">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1348"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1348">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1348"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12975,25 +8706,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0538">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1351"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bissau-Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1351">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1351"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13001,25 +8721,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0539">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1354"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mosotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1354">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1354"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13027,25 +8736,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0540">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1357"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malawian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1357">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1357"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13053,25 +8751,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0541">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1360"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1360">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1360"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13079,25 +8766,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0542">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1363"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mozambican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1363">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1363"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13105,25 +8781,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0543">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1366"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerien</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1366">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1366"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13131,25 +8796,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0544">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1369"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1369">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1369"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13157,25 +8811,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0545">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1372"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Rwandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1372">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1372"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13183,25 +8826,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0546">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1375"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swazi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1375">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1375"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13209,19 +8841,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0547">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1377"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Togolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1377">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0547"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1377"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13229,19 +8856,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0548">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1379"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tanzanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1379">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0548"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1379"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13249,19 +8871,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0549">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1381"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1381">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0549"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1381"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13269,25 +8886,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0550">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1384"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zimbabweian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1384">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1384"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13876,6 +9482,26 @@ category does not include all native populations within the Arctic circle for ex
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCIT_C25464 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C25464">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Country</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0000181 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000181"/>
+    
+
+
     <!-- http://urigen_local_uri/ae920f6d-eda5-40ab-8ec9-c5c08b7649af/Punjabi_Sikh -->
 
     <owl:Class rdf:about="http://urigen_local_uri/ae920f6d-eda5-40ab-8ec9-c5c08b7649af/Punjabi_Sikh">
@@ -13902,37 +9528,39 @@ category does not include all native populations within the Arctic circle for ex
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Oceania"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Central_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Melanesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Micronesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Middle_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Polynesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Scandinavia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-central_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/SouthAmerica"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Europe"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
         </owl:members>
     </rdf:Description>
 </rdf:RDF>

--- a/hancestro-full.json
+++ b/hancestro-full.json
@@ -19,9 +19,9 @@
         "val" : "http://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2023-10-13"
+        "val" : "2024-01-24"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro-full.json"
+      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro-full.json"
     },
     "nodes" : [ {
       "id" : "http://dbpedia.org/resource/Afghanistan",
@@ -30,6 +30,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00006882"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Africa",
+      "lbl" : "Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000457"
         } ]
       }
     }, {
@@ -120,6 +129,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00004025"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Asia",
+      "lbl" : "Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000465"
         } ]
       }
     }, {
@@ -352,6 +370,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Caribbean",
+      "lbl" : "Caribbean",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Cayman_Islands",
       "lbl" : "Cayman Islands",
       "type" : "CLASS",
@@ -367,6 +389,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00001089"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Central_America",
+      "lbl" : "Central America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002891"
         } ]
       }
     }, {
@@ -554,6 +585,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Africa",
+      "lbl" : "Eastern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000556"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Asia",
+      "lbl" : "Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002471"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Europe",
+      "lbl" : "Eastern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Ecuador",
       "lbl" : "Ecuador",
       "type" : "CLASS",
@@ -614,6 +667,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000567"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Europe",
+      "lbl" : "Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000464"
         } ]
       }
     }, {
@@ -1046,6 +1108,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "lbl" : "Latin America and the Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Latvia",
       "lbl" : "Latvia",
       "type" : "CLASS",
@@ -1238,6 +1309,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Melanesia",
+      "lbl" : "Melanesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005860"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Mexico",
       "lbl" : "Mexico",
       "type" : "CLASS",
@@ -1246,6 +1326,19 @@
           "val" : "GAZ:00002852"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Micronesia",
+      "lbl" : "Micronesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005862"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Middle_Africa",
+      "lbl" : "Middle Africa",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Moldova",
       "lbl" : "Moldova",
@@ -1452,6 +1545,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Northern_Africa",
+      "lbl" : "Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000555"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_America",
+      "lbl" : "Northern America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000458"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_Europe",
+      "lbl" : "Northern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "lbl" : "Northern Mariana Islands",
       "type" : "CLASS",
@@ -1471,6 +1586,15 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
           "val" : "Kingdom of Norway"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Oceania",
+      "lbl" : "Oceania",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000468"
         } ]
       }
     }, {
@@ -1586,6 +1710,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00002939"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Polynesia",
+      "lbl" : "Polynesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005861"
         } ]
       }
     }, {
@@ -1792,6 +1925,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Scandinavia",
+      "lbl" : "Scandinavia",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Scotland",
       "lbl" : "Scotland",
       "type" : "CLASS",
@@ -1891,12 +2028,43 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "lbl" : "South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000559"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South-central_Asia",
+      "lbl" : "South-Central Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/SouthAmerica",
+      "lbl" : "South America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/South_Africa",
       "lbl" : "South Africa",
       "type" : "CLASS",
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South_Asia",
+      "lbl" : "South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002472"
         } ]
       }
     }, {
@@ -1921,6 +2089,19 @@
           "val" : "GAZ:00233439"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Africa",
+      "lbl" : "Southern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Europe",
+      "lbl" : "Southern Europe",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Spain",
       "lbl" : "Spain",
@@ -2278,6 +2459,23 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Western_Africa",
+      "lbl" : "Western Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000554"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Asia",
+      "lbl" : "Western Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Europe",
+      "lbl" : "Western Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Western_Sahara",
       "lbl" : "Western Sahara",
       "type" : "CLASS",
@@ -2424,44 +2622,7 @@
       "meta" : {
         "definition" : {
           "val" : "An entity that has temporal parts and that happens, unfolds or develops through time."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "occurrent"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Occurrent"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000004",
@@ -2531,37 +2692,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000006",
       "lbl" : "spatial region",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "s-region"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "SpatialRegion"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Spatial regions do not participate in processes."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000015",
       "lbl" : "process",
@@ -2575,46 +2706,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000016",
       "lbl" : "disposition",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "disposition"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Disposition"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "an atom of element X has the disposition to decay to an atom of element Y"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "certain people have a predisposition to colon cancer"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "children are innately disposed to categorize objects in certain ways."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000017",
       "lbl" : "realizable entity",
@@ -2622,44 +2714,7 @@
       "meta" : {
         "definition" : {
           "val" : "A specifically dependent continuant  that inheres in continuant  entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "realizable"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "RealizableEntity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the disposition of this piece of metal to conduct electricity."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the disposition of your blood to coagulate"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of your reproductive organs"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of being a doctor"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of this boundary to delineate where Utah and Colorado meet"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000019",
@@ -2760,9 +2815,6 @@
           "val" : "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
           "val" : "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] "
         }, {
           "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
@@ -2776,114 +2828,12 @@
       "meta" : {
         "definition" : {
           "val" : "A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the priest role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a boundary to demarcate two neighboring administrative territories"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a building in serving as a military target"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a stone in marking a property boundary"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of subject in a clinical trial"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the student role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/BFO_0000031",
-      "lbl" : "generically dependent continuant",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"
-        },
-        "comments" : [ "A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time." ],
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "gdc"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "GenericallyDependentContinuant"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000034",
       "lbl" : "function",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "function"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Function"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of a hammer to drive in nails"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of a heart pacemaker to regulate the beating of a heart through electricity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of amylase in saliva to break down starch into sugar"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000040",
       "lbl" : "material entity",
@@ -3118,73 +3068,13 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000141",
       "lbl" : "immaterial entity",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "immaterial"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "ImmaterialEntity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000334",
-      "lbl" : "subcontinental land mass",
       "type" : "CLASS"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000370",
-      "lbl" : "geographical entity",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface)."
-        },
-        "comments" : [ "Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.\n\nGenerally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.", "Note that despite the word 'planetary' in 'planetary surface', it refers generally to surface of dwarf planets, asteroids, moons, etc.", "We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.", "We note that the term 'geography' is also applied to the Earth's moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  \n\nThus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc." ],
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
-          "val" : "geographical entity of astronomical body"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Mathias Brochhausen"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Matt Diller"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "William R. Hogan"
-        } ]
-      }
+      "id" : "http://purl.obolibrary.org/obo/COB_0000032",
+      "lbl" : "geographical location",
+      "type" : "CLASS"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000372",
-      "lbl" : "geographical region",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "François Modave"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Mathias Brochhausen"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Matt Diller"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "William R. Hogan"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000374",
+      "id" : "http://purl.obolibrary.org/obo/GAZ_00000013",
       "lbl" : "continent",
       "type" : "CLASS",
       "meta" : {
@@ -3194,26 +3084,6 @@
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "major area"
-        } ],
-        "xrefs" : [ {
-          "val" : "GAZ:00190836"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000375",
-      "lbl" : "land mass",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000391",
-      "lbl" : "geopolitical organization",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
-          "val" : "geopolitical organization"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Amanda Hicks"
         } ]
       }
     }, {
@@ -3231,7 +3101,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "lbl" : "country",
+      "lbl" : "obsolete country",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -3240,7 +3110,11 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "NCIT:C25464"
-        } ]
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
@@ -3446,152 +3320,234 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "lbl" : "Africa",
+      "lbl" : "obsolete Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000457"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "lbl" : "Asia",
+      "lbl" : "obsolete Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000465"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "lbl" : "Europe",
+      "lbl" : "obsolete Europe",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000464"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Europe"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "lbl" : "Oceania",
+      "lbl" : "obsolete Oceania",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000468"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Oceania"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "lbl" : "Latin America and the Caribbean",
+      "lbl" : "obsolete Latin America and the Caribbean",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "lbl" : "Northern America",
+      "lbl" : "obsolete Northern America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000458"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "lbl" : "Eastern Africa",
+      "lbl" : "obsolete Eastern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000556"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "lbl" : "Middle Africa",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "lbl" : "Northern Africa",
+      "lbl" : "obsolete Middle Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000555"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Middle_Africa"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
+      "lbl" : "obsolete Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "lbl" : "Southern Africa",
+      "lbl" : "obsolete Southern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000553"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "lbl" : "Western Africa",
+      "lbl" : "obsolete Western Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000554"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "lbl" : "South-Central Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "lbl" : "South-Eastern Asia",
+      "lbl" : "obsolete South Central Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000559"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-central_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
+      "lbl" : "obsolete South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "lbl" : "Western Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "lbl" : "Eastern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "lbl" : "Northern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "lbl" : "Southern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "lbl" : "Western Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "lbl" : "Caribbean",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "lbl" : "South America",
+      "lbl" : "obsolete Western Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
+      "lbl" : "obsolete Eastern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
+      "lbl" : "obsolete Northern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
+      "lbl" : "obsolete Southern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
+      "lbl" : "obsolete Western Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
+      "lbl" : "obsolete Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Caribbean"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
+      "lbl" : "obsolete South America",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/SouthAmerica"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "lbl" : "Central America",
+      "lbl" : "obsolete Central America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002891"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Central_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
@@ -3599,39 +3555,47 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "lbl" : "Melanesia",
+      "lbl" : "obsolete Melanesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005860"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Melanesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "lbl" : "Micronesia",
+      "lbl" : "obsolete Micronesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005862"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Micronesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "lbl" : "Polynesia",
+      "lbl" : "obsolete Polynesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005861"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Polynesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-      "lbl" : "Eastern Asia",
+      "lbl" : "obsolete Eastern Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002471"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0286",
@@ -3651,16 +3615,25 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "lbl" : "Scandinavia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "lbl" : "South Asia",
+      "lbl" : "obsolete Scandinavia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002472"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Scandinavia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
+      "lbl" : "obsolete South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
@@ -5040,9 +5013,6 @@
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -5067,23 +5037,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
       "lbl" : "definition",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/IAO_0000116",
-      "lbl" : "editor note",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000117",
       "lbl" : "term editor",
@@ -5097,23 +5051,11 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000118",
       "lbl" : "alternative_term",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000119",
       "lbl" : "definition_source",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000700",
       "lbl" : "has ontology root term",
@@ -5134,6 +5076,15 @@
       "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
       "lbl" : "term replaced by",
       "type" : "PROPERTY"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/NCIT_C25464",
+      "lbl" : "Country",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states."
+        }
+      }
     }, {
       "id" : "http://purl.obolibrary.org/obo/OBI_0000181",
       "lbl" : "population",
@@ -7247,2331 +7198,1073 @@
     "edges" : [ {
       "sub" : "http://dbpedia.org/resource/Afghanistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Albania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Algeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/American_Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Andorra",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Angola",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Anguilla",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Argentina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Armenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Aruba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Australia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Austria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Azerbaijan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bahrain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bangladesh",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Barbados",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belarus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belgium",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belize",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Benin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bermuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bhutan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bolivia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Botswana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brazil",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brunei",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bulgaria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burkina_Faso",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burundi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cambodia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cameroon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Canada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cape_Verde",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Cayman_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Central_African_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Central_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Chad",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Channel_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Chile",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/China",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Christmas_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Colombia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Comoros",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cook_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Costa_Rica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Croatia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cuba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Curacao",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cyprus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Czech_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Denmark",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Djibouti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominican_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/East_Timor",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Ecuador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Egypt",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/El_Salvador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Eritrea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Estonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ethiopia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Falkland_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Fiji",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Finland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/France",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Guiana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Polynesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gabon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Germany",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ghana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gibraltar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greece",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greenland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Grenada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guadeloupe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guatemala",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guyana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Haiti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Holy_See",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Honduras",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hong_Kong",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hungary",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iceland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/India",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Indonesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iran",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iraq",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Isle_of_Man",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Israel",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Italy",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ivory_Coast",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jamaica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Japan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jordan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kazakhstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kenya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kiribati",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kosovo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kuwait",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Laos",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Latvia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lebanon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lesotho",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liberia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Libya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liechtenstein",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lithuania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Luxembourg",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Macau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Madagascar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malawi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malaysia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Maldives",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mali",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malta",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Marshall_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Martinique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauretania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauritius",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mayotte",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Melanesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Mexico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Micronesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Middle_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Moldova",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Monaco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mongolia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montenegro",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montserrat",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Morocco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mozambique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Myanmar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Namibia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nauru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nepal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Caledonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Zealand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nicaragua",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niger",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nigeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niue",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norfolk_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/North_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norway",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Oceania",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Oman",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pakistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palestinian_territories",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Panama",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Paraguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Peru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Philippines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Poland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Polynesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Portugal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Puerto_Rico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Qatar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Romania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Russia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Rwanda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Réunion",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Helena",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Lucia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Martin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/San_Marino",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Scandinavia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Scotland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Senegal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Serbia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Seychelles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sierra_Leone",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Singapore",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sint_Maarten",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovakia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Solomon_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Somalia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-central_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/SouthAmerica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Africa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Spain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sri_Lanka",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Suriname",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Swaziland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sweden",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Switzerland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Syria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Taiwan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tajikistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tanzania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Thailand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Bahamas",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Gambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Togo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tokelau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tonga",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tunisia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkey",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkmenistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tuvalu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uganda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ukraine",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Kingdom",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uruguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uzbekistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vanuatu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Venezuela",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vietnam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Western_Sahara",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Yemen",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zimbabwe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Georgia_(country)",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/BFO_0000002",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000001"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/BFO_0000003",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000001"
     }, {
@@ -9607,10 +8300,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000017"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/BFO_0000031",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/BFO_0000034",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000016"
@@ -9623,41 +8312,17 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000004"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000334",
+      "sub" : "http://purl.obolibrary.org/obo/COB_0000032",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000375"
+      "obj" : "http://purl.obolibrary.org/obo/BFO_0000141"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000334",
-      "pred" : "http://purl.obolibrary.org/obo/BFO_0000137",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000370",
+      "sub" : "http://purl.obolibrary.org/obo/GAZ_00000013",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000040"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000372",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000370"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000374",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000375"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000375",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000372"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000391",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/OBI_0000245"
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000334"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000391"
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
       "pred" : "is_a",
@@ -9791,121 +8456,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0021"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0286",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
       "pred" : "is_a",
@@ -9929,13 +8486,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0307",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Italy",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Italy"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0309",
       "pred" : "is_a",
@@ -10035,13 +8586,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0321",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Finland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Finland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0322",
       "pred" : "is_a",
@@ -10069,203 +8614,83 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Western_Sahara",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Western_Sahara"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Anguilla",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Anguilla"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Barbados",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Barbados"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Haiti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Haiti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jamaica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jamaica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tajikistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tajikistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkmenistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkmenistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uzbekistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uzbekistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "is_a",
@@ -10273,53 +8698,23 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Afghanistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Afghanistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kazakhstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kazakhstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kyrgyzstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kyrgyzstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "is_a",
@@ -10327,13 +8722,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Albania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Albania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "is_a",
@@ -10341,13 +8730,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Andorra",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Andorra"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "is_a",
@@ -10355,13 +8738,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Australia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Australia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "is_a",
@@ -10369,13 +8746,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Austria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Austria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "is_a",
@@ -10383,13 +8754,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belarus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belarus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "is_a",
@@ -10397,13 +8762,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belgium",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belgium"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "is_a",
@@ -10411,13 +8770,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bermuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bermuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "is_a",
@@ -10425,13 +8778,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "is_a",
@@ -10439,13 +8786,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brazil",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brazil"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "is_a",
@@ -10453,13 +8794,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bulgaria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bulgaria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "is_a",
@@ -10467,13 +8802,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Canada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Canada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "is_a",
@@ -10481,13 +8810,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Channel_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Channel_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "is_a",
@@ -10495,13 +8818,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chile",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chile"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "is_a",
@@ -10509,13 +8826,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Croatia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Croatia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "is_a",
@@ -10523,13 +8834,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Czech_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Czech_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "is_a",
@@ -10537,13 +8842,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Denmark",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Denmark"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "is_a",
@@ -10551,13 +8850,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Estonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Estonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "is_a",
@@ -10565,13 +8858,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Faeroe_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Faeroe_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "is_a",
@@ -10579,13 +8866,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Falkland_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Falkland_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "is_a",
@@ -10593,13 +8874,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/France",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/France"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "is_a",
@@ -10607,13 +8882,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Germany",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Germany"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "is_a",
@@ -10621,13 +8890,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gibraltar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gibraltar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "is_a",
@@ -10635,13 +8898,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greece",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greece"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "is_a",
@@ -10649,13 +8906,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greenland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greenland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "is_a",
@@ -10663,13 +8914,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Hungary",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Hungary"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "is_a",
@@ -10677,13 +8922,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iceland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iceland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "is_a",
@@ -10691,13 +8930,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Isle_of_Man",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Isle_of_Man"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "is_a",
@@ -10705,13 +8938,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Latvia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Latvia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "is_a",
@@ -10719,13 +8946,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liechtenstein",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liechtenstein"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "is_a",
@@ -10733,13 +8954,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lithuania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lithuania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "is_a",
@@ -10747,13 +8962,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Luxembourg",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Luxembourg"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "is_a",
@@ -10761,13 +8970,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malta",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malta"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "is_a",
@@ -10775,13 +8978,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Monaco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Monaco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "is_a",
@@ -10789,13 +8986,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montenegro",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montenegro"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "is_a",
@@ -10803,23 +8994,11 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Zealand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Zealand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "is_a",
@@ -10827,13 +9006,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norfolk_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norfolk_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "is_a",
@@ -10841,13 +9014,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norway",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norway"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "is_a",
@@ -10855,13 +9022,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Poland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Poland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "is_a",
@@ -10869,13 +9030,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Portugal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Portugal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "is_a",
@@ -10883,13 +9038,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "is_a",
@@ -10897,13 +9046,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Moldova",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Moldova"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "is_a",
@@ -10911,33 +9054,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Romania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Romania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Russia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Russia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "is_a",
@@ -10945,13 +9070,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "is_a",
@@ -10959,13 +9078,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/San_Marino",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/San_Marino"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "is_a",
@@ -10973,13 +9086,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Serbia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Serbia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "is_a",
@@ -10987,13 +9094,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovakia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovakia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "is_a",
@@ -11001,13 +9102,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "is_a",
@@ -11015,13 +9110,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Spain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Spain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "is_a",
@@ -11029,13 +9118,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sweden",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sweden"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "is_a",
@@ -11043,13 +9126,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Switzerland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Switzerland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "is_a",
@@ -11057,13 +9134,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "is_a",
@@ -11071,1313 +9142,527 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ukraine",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ukraine"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Argentina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Argentina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Bahamas",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Bahamas"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belize",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belize"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bolivia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bolivia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cayman_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cayman_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Colombia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Colombia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Costa_Rica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Costa_Rica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cuba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cuba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Dominica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Dominica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ecuador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ecuador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/El_Salvador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/El_Salvador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Guiana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Guiana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Grenada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Grenada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guatemala",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guatemala"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guyana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guyana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Honduras",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Honduras"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Martinique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Martinique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mexico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mexico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montserrat",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montserrat"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nicaragua",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nicaragua"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Panama",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Panama"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Paraguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Paraguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Peru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Peru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Puerto_Rico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Puerto_Rico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Lucia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Lucia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Suriname",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Suriname"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uruguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uruguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Venezuela",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Venezuela"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Algeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Algeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Armenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Armenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Azerbaijan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Azerbaijan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bahrain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bahrain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cyprus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cyprus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Egypt",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Egypt"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Georgia_(country)",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Georgia_(country)"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iran",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iran"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iraq",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iraq"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Israel",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Israel"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jordan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jordan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kuwait",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kuwait"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lebanon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lebanon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Libya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Libya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Morocco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Morocco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palestinian_territories",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palestinian_territories"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Oman",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Oman"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Qatar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Qatar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saudi_Arabia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saudi_Arabia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tunisia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tunisia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkey",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkey"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Yemen",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Yemen"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Aruba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Aruba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Christmas_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Christmas_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Curacao",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Curacao"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kosovo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kosovo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Syria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Syria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "is_a",
@@ -12385,813 +9670,327 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Kingdom",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Kingdom"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/American_Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/American_Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cook_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cook_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Fiji",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Fiji"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Polynesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Polynesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kiribati",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kiribati"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Marshall_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Marshall_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nauru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nauru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Caledonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Caledonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niue",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niue"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Solomon_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Solomon_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tokelau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tokelau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tonga",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tonga"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tuvalu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tuvalu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vanuatu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vanuatu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bangladesh",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bangladesh"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bhutan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bhutan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/India",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/India"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Maldives",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Maldives"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nepal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nepal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pakistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pakistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sri_Lanka",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sri_Lanka"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brunei",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brunei"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cambodia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cambodia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Indonesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Indonesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Laos",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Laos"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malaysia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malaysia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Myanmar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Myanmar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Philippines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Philippines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Thailand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Thailand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/East_Timor",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/East_Timor"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vietnam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vietnam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cameroon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cameroon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "is_a",
@@ -13199,863 +9998,347 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cape_Verde",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cape_Verde"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chad",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chad"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ethiopia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ethiopia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kenya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kenya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liberia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liberia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Madagascar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Madagascar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauretania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauretania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauritius",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauritius"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mayotte",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mayotte"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Namibia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Namibia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Senegal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Senegal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Seychelles",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Seychelles"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sierra_Leone",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sierra_Leone"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Somalia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Somalia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Africa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Africa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Helena",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Helena"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uganda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uganda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Angola",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Angola"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Benin",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Benin"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Botswana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Botswana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burkina_Faso",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burkina_Faso"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burundi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burundi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Central_African_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Central_African_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Comoros",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Comoros"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ivory_Coast",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ivory_Coast"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Djibouti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Djibouti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Eritrea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Eritrea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gabon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gabon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Gambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Gambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ghana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ghana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea_Bissau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea_Bissau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lesotho",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lesotho"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malawi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malawi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mali",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mali"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mozambique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mozambique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niger",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niger"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nigeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nigeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Rwanda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Rwanda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Swaziland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Swaziland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "is_a",
@@ -14063,13 +10346,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Togo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Togo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "is_a",
@@ -14077,13 +10354,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tanzania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tanzania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "is_a",
@@ -14091,33 +10362,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zimbabwe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zimbabwe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0551",
       "pred" : "is_a",
@@ -14370,6 +10623,10 @@
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0598",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0487"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/NCIT_C25464",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/OBI_0000181",
       "pred" : "is_a",
@@ -14970,397 +11227,163 @@
       "allValuesFromEdges" : [ {
         "sub" : "http://dbpedia.org/resource/Afghanistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Albania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Algeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/American_Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Andorra",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Angola",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Anguilla",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Argentina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Armenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Aruba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Australia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Austria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Azerbaijan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bahrain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bangladesh",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Barbados",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Belarus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belgium",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belize",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Benin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Bhutan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bolivia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Botswana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Brazil",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Brunei",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bulgaria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Burkina_Faso",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Burundi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cambodia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Cameroon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cape_Verde",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cayman_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Central_African_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Chad",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Channel_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Chile",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/China",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Christmas_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -15368,1853 +11391,767 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Colombia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Comoros",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cook_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Costa_Rica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Croatia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Cuba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Curacao",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Cyprus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Czech_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Djibouti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominican_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/East_Timor",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Ecuador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Egypt",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/El_Salvador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Eritrea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Estonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ethiopia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Falkland_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Fiji",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Finland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/France",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Guiana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Polynesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Gabon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Germany",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ghana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Gibraltar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Greece",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Grenada",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guadeloupe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Guatemala",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guyana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Haiti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Holy_See",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Honduras",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Hong_Kong",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Hungary",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Iceland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/India",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Indonesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iran",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iraq",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Isle_of_Man",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Israel",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Italy",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ivory_Coast",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Jamaica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Japan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Jordan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kazakhstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kenya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Kiribati",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kosovo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044"
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Kuwait",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Laos",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Latvia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lebanon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Lesotho",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liberia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Libya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liechtenstein",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lithuania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Luxembourg",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Macau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Madagascar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malawi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malaysia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Maldives",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Mali",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malta",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Marshall_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Martinique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauretania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauritius",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mayotte",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mexico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Moldova",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Monaco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Mongolia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Montenegro",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Montserrat",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Morocco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mozambique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Myanmar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Namibia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nauru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Nepal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Caledonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Zealand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Nicaragua",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Niger",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nigeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Niue",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norfolk_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/North_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053"
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Oman",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pakistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palestinian_territories",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Panama",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Paraguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Peru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Philippines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Poland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Portugal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Puerto_Rico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Qatar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Romania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Rwanda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Réunion",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Helena",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Lucia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Martin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/San_Marino",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Scotland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Senegal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Serbia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Seychelles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sierra_Leone",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Singapore",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sint_Maarten",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovakia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Solomon_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Somalia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Africa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037"
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Spain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sri_Lanka",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Suriname",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Swaziland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Switzerland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Syria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043"
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Taiwan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055"
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tajikistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tanzania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Thailand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Bahamas",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Gambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Togo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Tokelau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tonga",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tunisia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkey",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkmenistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tuvalu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Uganda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Ukraine",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Kingdom",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Uruguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Uzbekistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Vanuatu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Venezuela",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Vietnam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Western_Sahara",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Yemen",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Zambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Zimbabwe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -17222,38 +12159,110 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Georgia_(country)",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
+        "sub" : "http://purl.obolibrary.org/obo/NCIT_C25464",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/BFO_0000050",
       "allValuesFromEdges" : [ {
+        "sub" : "http://dbpedia.org/resource/Caribbean",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Central_America",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Melanesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Micronesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Middle_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Polynesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Scandinavia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-central_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/SouthAmerica",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/BFO_0000002",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
@@ -17281,225 +12290,11 @@
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/GEO_000000374",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Oceania"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/HANCESTRO_0301",

--- a/hancestro-full.obo
+++ b/hancestro-full.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: hancestro/releases/2023-10-13/hancestro-full.owl
+data-version: hancestro/releases/2024-01-24/hancestro-full.owl
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_annotation_extension ""
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_gp2term ""
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_ontology ""
@@ -12,14 +12,14 @@ property_value: http://purl.org/dc/elements/1.1/title "Human Ancestry Ontology" 
 property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
 property_value: IAO:0000700 HANCESTRO:0004
 property_value: IAO:0000700 HANCESTRO:0304
-property_value: owl:versionInfo "2023-10-13" xsd:string
+property_value: owl:versionInfo "2024-01-24" xsd:string
 
 [Term]
 id: American:Samoa
 name: American Samoa
 xref: GAZ:00003957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: BFO:0000001
@@ -60,20 +60,7 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000003
 name: occurrent
 def: "An entity that has temporal parts and that happens, unfolds or develops through time." []
-is_a: BFO:0000001 ! entity
 relationship: BFO:0000050 BFO:0000003 {all_only="true"} ! part_of occurrent
-property_value: BFO:0000179 "occurrent" xsd:string
-property_value: BFO:0000180 "Occurrent" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players." xsd:string
-property_value: IAO:0000116 "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000006", comment="per discussion with Barry Smith"}
-property_value: IAO:0000116 "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000012"}
-property_value: IAO:0000600 "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/077-002"}
-property_value: IAO:0000601 "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
-property_value: IAO:0000601 "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
-property_value: IAO:0000602 "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
-property_value: IAO:0000602 "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000004
@@ -82,8 +69,6 @@ def: "b is an independent continuant = Def. b is a continuant which is such that
 comment: A continuant that is a bearer of quality and realizable entity entities, in which other entities inhere and which itself cannot inhere in anything.
 is_a: BFO:0000002 ! continuant
 disjoint_from: BFO:0000020 ! specifically dependent continuant
-disjoint_from: BFO:0000020 ! specifically dependent continuant
-disjoint_from: BFO:0000031 ! generically dependent continuant
 relationship: BFO:0000050 BFO:0000004 {all_only="true"} ! part_of independent continuant
 property_value: BFO:0000179 "ic" xsd:string
 property_value: BFO:0000180 "IndependentContinuant" xsd:string
@@ -108,15 +93,6 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000006
 name: spatial region
 is_a: BFO:0000141 ! immaterial entity
-property_value: BFO:0000179 "s-region" xsd:string
-property_value: BFO:0000180 "SpatialRegion" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Spatial regions do not participate in processes." xsd:string
-property_value: IAO:0000116 "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000002", comment="per discussion with Barry Smith"}
-property_value: IAO:0000600 "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
-property_value: IAO:0000601 "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
-property_value: IAO:0000602 "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
-property_value: IAO:0000602 "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000015
@@ -130,18 +106,6 @@ id: BFO:0000016
 name: disposition
 is_a: BFO:0000017 ! realizable entity
 disjoint_from: BFO:0000023 ! role
-property_value: BFO:0000179 "disposition" xsd:string
-property_value: BFO:0000180 "Disposition" xsd:string
-property_value: IAO:0000112 "an atom of element X has the disposition to decay to an atom of element Y" xsd:string
-property_value: IAO:0000112 "certain people have a predisposition to colon cancer" xsd:string
-property_value: IAO:0000112 "children are innately disposed to categorize objects in certain ways." xsd:string
-property_value: IAO:0000112 "the cell wall is disposed to filter chemicals in endocytosis and exocytosis" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type." xsd:string
-property_value: IAO:0000600 "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
-property_value: IAO:0000601 "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
-property_value: IAO:0000602 "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
-property_value: IAO:0000602 "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000017
@@ -150,18 +114,6 @@ def: "A specifically dependent continuant  that inheres in continuant  entities 
 is_a: BFO:0000020 ! specifically dependent continuant
 disjoint_from: BFO:0000019 ! quality
 relationship: BFO:0000050 BFO:0000017 {all_only="true"} ! part_of realizable entity
-property_value: BFO:0000179 "realizable" xsd:string
-property_value: BFO:0000180 "RealizableEntity" xsd:string
-property_value: IAO:0000112 "the disposition of this piece of metal to conduct electricity." xsd:string
-property_value: IAO:0000112 "the disposition of your blood to coagulate" xsd:string
-property_value: IAO:0000112 "the function of your reproductive organs" xsd:string
-property_value: IAO:0000112 "the role of being a doctor" xsd:string
-property_value: IAO:0000112 "the role of this boundary to delineate where Utah and Colorado meet" xsd:string
-property_value: IAO:0000600 "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
-property_value: IAO:0000601 "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
-property_value: IAO:0000602 "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
-property_value: IAO:0000602 "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000019
@@ -185,11 +137,9 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 [Term]
 id: BFO:0000020
 name: specifically dependent continuant
-def: "b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/131-004"}
 def: "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
 comment: A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.
 is_a: BFO:0000002 ! continuant
-disjoint_from: BFO:0000031 ! generically dependent continuant
 relationship: BFO:0000050 BFO:0000020 {all_only="true"} ! part_of specifically dependent continuant
 property_value: BFO:0000179 "sdc" xsd:string
 property_value: BFO:0000180 "SpecificallyDependentContinuant" xsd:string
@@ -205,7 +155,6 @@ property_value: IAO:0000112 "the role of being a doctor" xsd:string
 property_value: IAO:0000112 "the shape of this hole." xsd:string
 property_value: IAO:0000112 "the smell of this portion of mozzarella" xsd:string
 property_value: IAO:0000116 "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000005", comment="per discussion with Barry Smith"}
-property_value: IAO:0000602 "(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/131-004"}
 property_value: IAO:0000602 "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
 property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
@@ -214,47 +163,11 @@ id: BFO:0000023
 name: role
 def: "A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts." []
 is_a: BFO:0000017 ! realizable entity
-property_value: BFO:0000179 "role" xsd:string
-property_value: BFO:0000180 "Role" xsd:string
-property_value: IAO:0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married." xsd:string
-property_value: IAO:0000112 "the priest role" xsd:string
-property_value: IAO:0000112 "the role of a boundary to demarcate two neighboring administrative territories" xsd:string
-property_value: IAO:0000112 "the role of a building in serving as a military target" xsd:string
-property_value: IAO:0000112 "the role of a stone in marking a property boundary" xsd:string
-property_value: IAO:0000112 "the role of subject in a clinical trial" xsd:string
-property_value: IAO:0000112 "the student role" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives." xsd:string
-property_value: IAO:0000600 "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
-property_value: IAO:0000602 "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
-
-[Term]
-id: BFO:0000031
-name: generically dependent continuant
-def: "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
-comment: A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.
-is_a: BFO:0000002 ! continuant
-property_value: BFO:0000179 "gdc" xsd:string
-property_value: BFO:0000180 "GenericallyDependentContinuant" xsd:string
-property_value: IAO:0000112 "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity." xsd:string
-property_value: IAO:0000112 "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop" xsd:string
-property_value: IAO:0000112 "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule." xsd:string
-property_value: IAO:0000602 "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000034
 name: function
 is_a: BFO:0000016 ! disposition
-property_value: BFO:0000179 "function" xsd:string
-property_value: BFO:0000180 "Function" xsd:string
-property_value: IAO:0000112 "the function of a hammer to drive in nails" xsd:string
-property_value: IAO:0000112 "the function of a heart pacemaker to regulate the beating of a heart through electricity" xsd:string
-property_value: IAO:0000112 "the function of amylase in saliva to break down starch into sugar" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc." xsd:string
-property_value: IAO:0000600 "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
-property_value: IAO:0000602 "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000040
@@ -291,102 +204,130 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000141
 name: immaterial entity
 is_a: BFO:0000004 ! independent continuant
-property_value: BFO:0000179 "immaterial" xsd:string
-property_value: BFO:0000180 "ImmaterialEntity" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10" xsd:string
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: Burkina:Faso
 name: Burkina Faso
 xref: GAZ:00000905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
+
+[Term]
+id: COB:0000032
+name: geographical location
+is_a: BFO:0000141 ! immaterial entity
 
 [Term]
 id: Cape:Verde
 name: Cape Verde
 xref: GAZ:00001227
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Cayman:Islands
 name: Cayman Islands
 xref: GAZ:00003986
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
+
+[Term]
+id: Central:America
+name: Central America
+xref: GAZ:00002891
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: Channel:Islands
 name: Channel Islands
 xref: GAZ:00001539
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: Christmas:Island
 name: Christmas Island
 xref: GAZ:00005915
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: Cook:Islands
 name: Cook Islands
 xref: GAZ:00053798
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: Costa:Rica
 name: Costa Rica
 xref: GAZ:00002901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: Czech:Republic
 name: Czech Republic
 xref: GAZ:00002954
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: Dominican:Republic
 name: Dominican Republic
 xref: GAZ:00003952
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: East:Timor
 name: East Timor
 synonym: "Timor-Leste" EXACT []
 xref: GAZ:00006913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
+
+[Term]
+id: Eastern:Africa
+name: Eastern Africa
+xref: GAZ:00000556
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Eastern:Asia
+name: Eastern Asia
+xref: GAZ:00002471
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Eastern:Europe
+name: Eastern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: El:Salvador
 name: El Salvador
 xref: GAZ:00002935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: Equatorial:Guinea
 name: Equatorial Guinea
 xref: GAZ:00001091
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: Faeroe:Islands
 name: Faeroe Islands
 xref: GAZ:00059206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 property_value: IAO:0000118 "Faroe Islands" xsd:string
 
 [Term]
@@ -394,73 +335,29 @@ id: Falkland:Islands
 name: Falkland Islands
 synonym: "Falkland Islands (Malvinas)" EXACT []
 xref: GAZ:00001412
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: French:Guiana
 name: French Guiana
 xref: GAZ:00002516
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: French:Polynesia
 name: French Polynesia
 xref: GAZ:00002918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
-id: GEO:000000334
-name: subcontinental land mass
-is_a: GEO:000000375 ! land mass
-relationship: BFO:0000137 GEO:000000374 ! continent
-
-[Term]
-id: GEO:000000370
-name: geographical entity
-def: "A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface)." []
-comment: Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.\n\nGenerally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.
-comment: Note that despite the word 'planetary' in 'planetary surface', it refers generally to surface of dwarf planets, asteroids, moons, etc.
-comment: We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.
-comment: We note that the term 'geography' is also applied to the Earth's moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  \n\nThus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc.
-is_a: BFO:0000040 ! material entity
-property_value: IAO:0000111 "geographical entity of astronomical body" xsd:string
-property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
-property_value: IAO:0000117 "Matt Diller" xsd:string
-property_value: IAO:0000117 "William R. Hogan" xsd:string
-
-[Term]
-id: GEO:000000372
-name: geographical region
-def: "A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface." []
-is_a: GEO:000000370 ! geographical entity
-property_value: IAO:0000117 "François Modave" xsd:string
-property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
-property_value: IAO:0000117 "Matt Diller" xsd:string
-property_value: IAO:0000117 "William R. Hogan" xsd:string
-
-[Term]
-id: GEO:000000374
+id: GAZ:00000013
 name: continent
 def: "One of the large, unbroken masses of land into which the Earth's surface is divided." []
 synonym: "major area" EXACT []
-xref: GAZ:00190836
-is_a: GEO:000000375 ! land mass
-
-[Term]
-id: GEO:000000375
-name: land mass
-is_a: GEO:000000372 ! geographical region
-
-[Term]
-id: GEO:000000391
-name: geopoli organization
-name: geopolitical organization
-is_a: OBI:0000245 ! organization
-property_value: IAO:0000111 "geopolitical organization" xsd:string
-property_value: IAO:0000117 "Amanda Hicks" xsd:string
+is_a: COB:0000032 ! geographical location
 
 [Term]
 id: GO:0016301
@@ -469,31 +366,31 @@ id: GO:0016301
 id: Georgia:(country)
 name: Georgia
 xref: GAZ:00004942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Guinea:Bissau
 name: Guinea-Bissau
 xref: GAZ:00000910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: HANCESTRO:0002
 name: region
 def: "Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable." []
 synonym: "geographical area" EXACT []
-is_a: GEO:000000334 ! subcontinental land mass
-relationship: BFO:0000050 GEO:000000374 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of continent
+is_a: COB:0000032 ! geographical location
+relationship: BFO:0000050 GAZ:00000013 {all_only="true"} ! part_of continent
 
 [Term]
 id: HANCESTRO:0003
-name: country
+name: obsolete country
 def: "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states." []
-is_a: GEO:000000391 ! geopoli organization
-relationship: RO:0001025 HANCESTRO:0002 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in region
 property_value: IAO:0000119 "NCIT:C25464" xsd:string
+is_obsolete: true
+replaced_by: http://purl.obolibrary.org/obo/NCIT_C25464
 
 [Term]
 id: HANCESTRO:0004
@@ -646,174 +543,159 @@ is_a: HANCESTRO:0021 ! Chinese
 
 [Term]
 id: HANCESTRO:0029
-name: Africa
-xref: GAZ:00000457
-is_a: GEO:000000374 ! continent
-disjoint_from: HANCESTRO:0030 ! Asia
+name: obsolete Africa
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Africa
 
 [Term]
 id: HANCESTRO:0030
-name: Asia
-xref: GAZ:00000465
-is_a: GEO:000000374 ! continent
+name: obsolete Asia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Asia
 
 [Term]
 id: HANCESTRO:0031
-name: Europe
-xref: GAZ:00000464
-is_a: GEO:000000374 ! continent
+name: obsolete Europe
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Europe
 
 [Term]
 id: HANCESTRO:0032
-name: Oceania
-xref: GAZ:00000468
-is_a: GEO:000000374 ! continent
+name: obsolete Oceania
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Oceania
 
 [Term]
 id: HANCESTRO:0033
-name: Latin America and the Caribbean
-xref: GAZ:00000459
-is_a: GEO:000000374 ! continent
+name: obsolete Latin America and the Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
 
 [Term]
 id: HANCESTRO:0034
-name: Northern America
-xref: GAZ:00000458
-is_a: GEO:000000374 ! continent
+name: obsolete Northern America
+is_obsolete: true
+replaced_by: Northern:America
 
 [Term]
 id: HANCESTRO:0035
-name: Eastern Africa
-xref: GAZ:00000556
-is_a: HANCESTRO:0002 ! region
-disjoint_from: HANCESTRO:0036 ! Middle Africa
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Eastern Africa
+is_obsolete: true
+replaced_by: Eastern:Africa
 
 [Term]
 id: HANCESTRO:0036
-name: Middle Africa
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Middle Africa
+is_obsolete: true
+replaced_by: Middle:Africa
 
 [Term]
 id: HANCESTRO:0037
-name: Northern Africa
-xref: GAZ:00000555
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Northern Africa
+is_obsolete: true
+replaced_by: Northern:Africa
 
 [Term]
 id: HANCESTRO:0038
-name: Southern Africa
-xref: GAZ:00000553
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Southern Africa
+is_obsolete: true
+replaced_by: Southern:Africa
 
 [Term]
 id: HANCESTRO:0039
-name: Western Africa
-xref: GAZ:00000554
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Western Africa
+is_obsolete: true
+replaced_by: Western:Africa
 
 [Term]
 id: HANCESTRO:0041
-name: South-Central Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South Central Asia
+is_obsolete: true
+replaced_by: South-central:Asia
 
 [Term]
 id: HANCESTRO:0042
-name: South-Eastern Asia
-xref: GAZ:00000559
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South-Eastern Asia
+is_obsolete: true
+replaced_by: South-Eastern:Asia
 
 [Term]
 id: HANCESTRO:0043
-name: Western Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Western Asia
+is_obsolete: true
+replaced_by: Western:Asia
 
 [Term]
 id: HANCESTRO:0044
-name: Eastern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Eastern Europe
+is_obsolete: true
+replaced_by: Eastern:Europe
 
 [Term]
 id: HANCESTRO:0045
-name: Northern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Northern Europe
+is_obsolete: true
+replaced_by: Northern:Europe
 
 [Term]
 id: HANCESTRO:0046
-name: Southern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Southern Europe
+is_obsolete: true
+replaced_by: Southern:Europe
 
 [Term]
 id: HANCESTRO:0047
-name: Western Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Western Europe
+is_obsolete: true
+replaced_by: Western:Europe
 
 [Term]
 id: HANCESTRO:0048
-name: Caribbean
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Caribbean
 
 [Term]
 id: HANCESTRO:0049
-name: South America
-xref: GAZ:00000459
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete South America
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/SouthAmerica
 
 [Term]
 id: HANCESTRO:0050
-name: Central America
-xref: GAZ:00002891
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Central America
+is_obsolete: true
+replaced_by: Central:America
 
 [Term]
 id: HANCESTRO:0051
 name: Australia/New Zealand
 is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: HANCESTRO:0052
-name: Melanesia
-xref: GAZ:00005860
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Melanesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Melanesia
 
 [Term]
 id: HANCESTRO:0053
-name: Micronesia
-xref: GAZ:00005862
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Micronesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Micronesia
 
 [Term]
 id: HANCESTRO:0054
-name: Polynesia
-xref: GAZ:00005861
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Polynesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Polynesia
 
 [Term]
 id: HANCESTRO:0055
-name: Eastern Asia
-xref: GAZ:00002471
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Eastern Asia
+is_obsolete: true
+replaced_by: Eastern:Asia
 
 [Term]
 id: HANCESTRO:0286
@@ -823,15 +705,15 @@ is_a: HANCESTRO:0008 ! Asian
 
 [Term]
 id: HANCESTRO:0288
-name: Scandinavia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0045 {all_only="true"} ! part_of Northern Europe
+name: obsolete Scandinavia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Scandinavia
 
 [Term]
 id: HANCESTRO:0289
-name: South Asia
-xref: GAZ:00002472
-is_a: HANCESTRO:0002 ! region
+name: obsolete South Asia
+is_obsolete: true
+replaced_by: South:Asia
 
 [Term]
 id: HANCESTRO:0290
@@ -865,7 +747,7 @@ is_a: HANCESTRO:0304 ! ancestry status
 id: HANCESTRO:0307
 name: Italian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Italy
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy ! isDemonymOf Italy
 
 [Term]
 id: HANCESTRO:0309
@@ -962,7 +844,7 @@ is_a: HANCESTRO:0005 ! European
 id: HANCESTRO:0321
 name: Finnish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Finland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland ! isDemonymOf Finland
 
 [Term]
 id: HANCESTRO:0322
@@ -995,1323 +877,1323 @@ is_obsolete: true
 [Term]
 id: HANCESTRO:0331
 name: Sudanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sudan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan ! isDemonymOf Sudan
 
 [Term]
 id: HANCESTRO:0332
 name: Sahrawi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Western:Sahara {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Western Sahara
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Western:Sahara ! isDemonymOf Western Sahara
 
 [Term]
 id: HANCESTRO:0333
 name: Anguillan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Anguilla
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla ! isDemonymOf Anguilla
 
 [Term]
 id: HANCESTRO:0334
 name: Antiguan or Barbudan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Antigua and Barbuda
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda ! isDemonymOf Antigua and Barbuda
 
 [Term]
 id: HANCESTRO:0335
 name: Barbadian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Barbados
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados ! isDemonymOf Barbados
 
 [Term]
 id: HANCESTRO:0336
 name: Haitian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Haiti
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti ! isDemonymOf Haiti
 
 [Term]
 id: HANCESTRO:0337
 name: Jamaican
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jamaica
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica ! isDemonymOf Jamaica
 
 [Term]
 id: HANCESTRO:0338
 name: Tajikistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tajikistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan ! isDemonymOf Tajikistan
 
 [Term]
 id: HANCESTRO:0339
 name: Turkmen
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkmenistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan ! isDemonymOf Turkmenistan
 
 [Term]
 id: HANCESTRO:0340
 name: Uzbekistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uzbekistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan ! isDemonymOf Uzbekistan
 
 [Term]
 id: HANCESTRO:0341
 name: Afghan
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Afghanistan
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan ! isDemonymOf Afghanistan
 
 [Term]
 id: HANCESTRO:0342
 name: Kazakhstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kazakhstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan ! isDemonymOf Kazakhstan
 
 [Term]
 id: HANCESTRO:0343
 name: Kyrgyzstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kyrgyzstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan ! isDemonymOf Kyrgyzstan
 
 [Term]
 id: HANCESTRO:0344
 name: Albanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Albania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania ! isDemonymOf Albania
 
 [Term]
 id: HANCESTRO:0345
 name: Andorran
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Andorra
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra ! isDemonymOf Andorra
 
 [Term]
 id: HANCESTRO:0346
 name: Australian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Australia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia ! isDemonymOf Australia
 
 [Term]
 id: HANCESTRO:0347
 name: Austrian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Austria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria ! isDemonymOf Austria
 
 [Term]
 id: HANCESTRO:0348
 name: Belarusian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belarus
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus ! isDemonymOf Belarus
 
 [Term]
 id: HANCESTRO:0349
 name: Belgian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belgium
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium ! isDemonymOf Belgium
 
 [Term]
 id: HANCESTRO:0350
 name: Bermudian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bermuda
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda ! isDemonymOf Bermuda
 
 [Term]
 id: HANCESTRO:0351
 name: Bosnian or Herzegovinian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bosnia and Herzegovina
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina ! isDemonymOf Bosnia and Herzegovina
 
 [Term]
 id: HANCESTRO:0352
 name: Brazilian
 is_a: HANCESTRO:0014 ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brazil
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil ! isDemonymOf Brazil
 
 [Term]
 id: HANCESTRO:0353
 name: Bulgarian
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bulgaria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria ! isDemonymOf Bulgaria
 
 [Term]
 id: HANCESTRO:0354
 name: Canadian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Canada
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada ! isDemonymOf Canada
 
 [Term]
 id: HANCESTRO:0355
 name: Channel Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Channel:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Channel Islands
+relationship: HANCESTRO:0330 Channel:Islands ! isDemonymOf Channel Islands
 
 [Term]
 id: HANCESTRO:0356
 name: Chilean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chile
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile ! isDemonymOf Chile
 
 [Term]
 id: HANCESTRO:0357
 name: Croatian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Croatia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia ! isDemonymOf Croatia
 
 [Term]
 id: HANCESTRO:0358
 name: Czech
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Czech:Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Czech Republic
+relationship: HANCESTRO:0330 Czech:Republic ! isDemonymOf Czech Republic
 
 [Term]
 id: HANCESTRO:0359
 name: Danish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Denmark
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark ! isDemonymOf Denmark
 
 [Term]
 id: HANCESTRO:0360
 name: Estonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Estonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia ! isDemonymOf Estonia
 
 [Term]
 id: HANCESTRO:0361
 name: Faroese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Faeroe:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Faeroe Islands
+relationship: HANCESTRO:0330 Faeroe:Islands ! isDemonymOf Faeroe Islands
 
 [Term]
 id: HANCESTRO:0362
 name: Falkland Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Falkland:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Falkland Islands
+relationship: HANCESTRO:0330 Falkland:Islands ! isDemonymOf Falkland Islands
 
 [Term]
 id: HANCESTRO:0363
 name: French
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/France {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf France
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/France ! isDemonymOf France
 
 [Term]
 id: HANCESTRO:0364
 name: German
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Germany
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany ! isDemonymOf Germany
 
 [Term]
 id: HANCESTRO:0365
 name: Gibraltarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gibraltar
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar ! isDemonymOf Gibraltar
 
 [Term]
 id: HANCESTRO:0366
 name: Greek
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greece
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece ! isDemonymOf Greece
 
 [Term]
 id: HANCESTRO:0367
 name: Greenlander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greenland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland ! isDemonymOf Greenland
 
 [Term]
 id: HANCESTRO:0368
 name: Hungarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Hungary
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary ! isDemonymOf Hungary
 
 [Term]
 id: HANCESTRO:0369
 name: Icelandic
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iceland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland ! isDemonymOf Iceland
 
 [Term]
 id: HANCESTRO:0370
 name: Manx
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Isle of Man
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man ! isDemonymOf Isle of Man
 
 [Term]
 id: HANCESTRO:0371
 name: Latvian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Latvia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia ! isDemonymOf Latvia
 
 [Term]
 id: HANCESTRO:0372
 name: Liechtensteiner
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liechtenstein
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein ! isDemonymOf Liechtenstein
 
 [Term]
 id: HANCESTRO:0373
 name: Lithuanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lithuania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania ! isDemonymOf Lithuania
 
 [Term]
 id: HANCESTRO:0374
 name: Luxembourgish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Luxembourg
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg ! isDemonymOf Luxembourg
 
 [Term]
 id: HANCESTRO:0375
 name: Maltese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malta
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta ! isDemonymOf Malta
 
 [Term]
 id: HANCESTRO:0376
 name: Monegasque
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Monaco
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco ! isDemonymOf Monaco
 
 [Term]
 id: HANCESTRO:0377
 name: Montenegrin
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montenegro
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro ! isDemonymOf Montenegro
 
 [Term]
 id: HANCESTRO:0378
 name: New Zealandish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Zealand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Zealand
+relationship: HANCESTRO:0330 New:Zealand ! isDemonymOf New Zealand
 
 [Term]
 id: HANCESTRO:0379
 name: Norfolk Islander
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
+is_a: HANCESTRO:0018 ! uncategorised population
 is_a: HANCESTRO:0290 ! genetically isolated population
 relationship: HANCESTRO:0301 HANCESTRO:0305 {all_only="true"} ! hasAncestryStatus genetically isolated ancestry
-relationship: HANCESTRO:0330 Norfolk:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norfolk Island
+relationship: HANCESTRO:0330 Norfolk:Island ! isDemonymOf Norfolk Island
 
 [Term]
 id: HANCESTRO:0380
 name: Norwegian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norway
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway ! isDemonymOf Norway
 
 [Term]
 id: HANCESTRO:0381
 name: Polish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Poland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland ! isDemonymOf Poland
 
 [Term]
 id: HANCESTRO:0382
 name: Portugese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Portugal
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal ! isDemonymOf Portugal
 
 [Term]
 id: HANCESTRO:0383
 name: Irish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Ireland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland ! isDemonymOf Republic of Ireland
 
 [Term]
 id: HANCESTRO:0384
 name: Moldovan
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Moldova
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova ! isDemonymOf Moldova
 
 [Term]
 id: HANCESTRO:0385
 name: Romanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Romania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania ! isDemonymOf Romania
 
 [Term]
 id: HANCESTRO:0386
 name: Russian
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Russia
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia ! isDemonymOf Russia
 
 [Term]
 id: HANCESTRO:0387
 name: Saint-Pierrais or Miquelonnais
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Pierre and Miquelon
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon ! isDemonymOf Saint Pierre and Miquelon
 
 [Term]
 id: HANCESTRO:0388
 name: Sammarinese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 San:Marino {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf San Marino
+relationship: HANCESTRO:0330 San:Marino ! isDemonymOf San Marino
 
 [Term]
 id: HANCESTRO:0389
 name: Serb
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Serbia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia ! isDemonymOf Serbia
 
 [Term]
 id: HANCESTRO:0390
 name: Slovak
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovakia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia ! isDemonymOf Slovakia
 
 [Term]
 id: HANCESTRO:0391
 name: Slovene
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovenia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia ! isDemonymOf Slovenia
 
 [Term]
 id: HANCESTRO:0392
 name: Spanish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Spain
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain ! isDemonymOf Spain
 
 [Term]
 id: HANCESTRO:0393
 name: Swedish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sweden
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden ! isDemonymOf Sweden
 
 [Term]
 id: HANCESTRO:0394
 name: Swiss
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Switzerland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland ! isDemonymOf Switzerland
 
 [Term]
 id: HANCESTRO:0395
 name: Macedonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Macedonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia ! isDemonymOf Republic of Macedonia
 
 [Term]
 id: HANCESTRO:0396
 name: Ukrainian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ukraine
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine ! isDemonymOf Ukraine
 
 [Term]
 id: HANCESTRO:0397
 name: Argentine
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Argentina
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina ! isDemonymOf Argentina
 
 [Term]
 id: HANCESTRO:0398
 name: Bahamian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 The:Bahamas {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Bahamas
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 The:Bahamas ! isDemonymOf The Bahamas
 
 [Term]
 id: HANCESTRO:0399
 name: Belizean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belize
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize ! isDemonymOf Belize
 
 [Term]
 id: HANCESTRO:0400
 name: Bolivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bolivia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia ! isDemonymOf Bolivia
 
 [Term]
 id: HANCESTRO:0401
 name: British Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf British Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands ! isDemonymOf British Virgin Islands
 
 [Term]
 id: HANCESTRO:0402
 name: Caymanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cayman:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cayman Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cayman:Islands ! isDemonymOf Cayman Islands
 
 [Term]
 id: HANCESTRO:0403
 name: Colombian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Colombia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia ! isDemonymOf Colombia
 
 [Term]
 id: HANCESTRO:0404
 name: Costa Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Costa:Rica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Costa Rica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Costa:Rica ! isDemonymOf Costa Rica
 
 [Term]
 id: HANCESTRO:0405
 name: Cuban
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cuba
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba ! isDemonymOf Cuba
 
 [Term]
 id: HANCESTRO:0406
 name: Dominican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Dominica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica ! isDemonymOf Dominica
 
 [Term]
 id: HANCESTRO:0407
 name: Ecuadorian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ecuador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador ! isDemonymOf Ecuador
 
 [Term]
 id: HANCESTRO:0408
 name: Salvadoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 El:Salvador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf El Salvador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 El:Salvador ! isDemonymOf El Salvador
 
 [Term]
 id: HANCESTRO:0409
 name: French Guianese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Guiana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Guiana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Guiana ! isDemonymOf French Guiana
 
 [Term]
 id: HANCESTRO:0410
 name: Grenadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Grenada
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada ! isDemonymOf Grenada
 
 [Term]
 id: HANCESTRO:0411
 name: Guatemalan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guatemala
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala ! isDemonymOf Guatemala
 
 [Term]
 id: HANCESTRO:0412
 name: Guyanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guyana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana ! isDemonymOf Guyana
 
 [Term]
 id: HANCESTRO:0413
 name: Honduran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Honduras
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras ! isDemonymOf Honduras
 
 [Term]
 id: HANCESTRO:0414
 name: Martinican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Martinique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique ! isDemonymOf Martinique
 
 [Term]
 id: HANCESTRO:0415
 name: Mexican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mexico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico ! isDemonymOf Mexico
 
 [Term]
 id: HANCESTRO:0416
 name: Montserratian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montserrat
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat ! isDemonymOf Montserrat
 
 [Term]
 id: HANCESTRO:0417
 name: Nicaraguan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nicaragua
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua ! isDemonymOf Nicaragua
 
 [Term]
 id: HANCESTRO:0418
 name: Panamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Panama
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama ! isDemonymOf Panama
 
 [Term]
 id: HANCESTRO:0419
 name: Paraguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Paraguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay ! isDemonymOf Paraguay
 
 [Term]
 id: HANCESTRO:0420
 name: Peruvian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Peru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru ! isDemonymOf Peru
 
 [Term]
 id: HANCESTRO:0421
 name: Puerto Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Puerto:Rico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Puerto Rico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Puerto:Rico ! isDemonymOf Puerto Rico
 
 [Term]
 id: HANCESTRO:0422
 name: Kittitian or Nevisian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Kitts and Nevis
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis ! isDemonymOf Saint Kitts and Nevis
 
 [Term]
 id: HANCESTRO:0423
 name: Saint Lucian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Lucia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Lucia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Lucia ! isDemonymOf Saint Lucia
 
 [Term]
 id: HANCESTRO:0424
 name: Saint Vincentian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Vincent and the Grenadines
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines ! isDemonymOf Saint Vincent and the Grenadines
 
 [Term]
 id: HANCESTRO:0425
 name: Surinamese
 synonym: "Surinamer" EXACT []
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Suriname
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname ! isDemonymOf Suriname
 
 [Term]
 id: HANCESTRO:0426
 name: Trinidadian or Tobagonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Trinidad and Tobago
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago ! isDemonymOf Trinidad and Tobago
 
 [Term]
 id: HANCESTRO:0427
 name: Turks and Caicos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turks and Caicos Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands ! isDemonymOf Turks and Caicos Islands
 
 [Term]
 id: HANCESTRO:0428
 name: Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands ! isDemonymOf United States Virgin Islands
 
 [Term]
 id: HANCESTRO:0429
 name: Uruguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uruguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay ! isDemonymOf Uruguay
 
 [Term]
 id: HANCESTRO:0430
 name: Venezuelan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Venezuela
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela ! isDemonymOf Venezuela
 
 [Term]
 id: HANCESTRO:0431
 name: Algerian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Algeria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria ! isDemonymOf Algeria
 
 [Term]
 id: HANCESTRO:0432
 name: Armenian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Armenia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia ! isDemonymOf Armenia
 
 [Term]
 id: HANCESTRO:0433
 name: Azerbaijani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Azerbaijan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan ! isDemonymOf Azerbaijan
 
 [Term]
 id: HANCESTRO:0434
 name: Bahraini
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bahrain
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain ! isDemonymOf Bahrain
 
 [Term]
 id: HANCESTRO:0435
 name: Cypriote
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cyprus
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus ! isDemonymOf Cyprus
 
 [Term]
 id: HANCESTRO:0436
 name: Egyptian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Egypt
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt ! isDemonymOf Egypt
 
 [Term]
 id: HANCESTRO:0437
 name: Georgian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Georgia:(country) {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Georgia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Georgia:(country) ! isDemonymOf Georgia
 
 [Term]
 id: HANCESTRO:0438
 name: Iranian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iran
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran ! isDemonymOf Iran
 
 [Term]
 id: HANCESTRO:0439
 name: Iraqi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iraq
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq ! isDemonymOf Iraq
 
 [Term]
 id: HANCESTRO:0440
 name: Israeli
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Israel
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel ! isDemonymOf Israel
 
 [Term]
 id: HANCESTRO:0441
 name: Jordanian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jordan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan ! isDemonymOf Jordan
 
 [Term]
 id: HANCESTRO:0442
 name: Kuwaiti
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kuwait
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait ! isDemonymOf Kuwait
 
 [Term]
 id: HANCESTRO:0443
 name: Lebanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lebanon
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon ! isDemonymOf Lebanon
 
 [Term]
 id: HANCESTRO:0444
 name: Libyan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Libya
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya ! isDemonymOf Libya
 
 [Term]
 id: HANCESTRO:0445
 name: Moroccan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Morocco
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco ! isDemonymOf Morocco
 
 [Term]
 id: HANCESTRO:0446
 name: Palestinian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Palestinian:territories {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palestinian Territories
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Palestinian:territories ! isDemonymOf Palestinian Territories
 
 [Term]
 id: HANCESTRO:0447
 name: Omani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Oman
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman ! isDemonymOf Oman
 
 [Term]
 id: HANCESTRO:0448
 name: Qatari
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Qatar
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar ! isDemonymOf Qatar
 
 [Term]
 id: HANCESTRO:0449
 name: Saudi
 synonym: "Saudi Arab" EXACT []
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Saudi:Arabia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saudi Arabia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Saudi:Arabia ! isDemonymOf Saudi Arabia
 
 [Term]
 id: HANCESTRO:0450
 name: Tunisian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tunisia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia ! isDemonymOf Tunisia
 
 [Term]
 id: HANCESTRO:0451
 name: Turkish
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkey
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey ! isDemonymOf Turkey
 
 [Term]
 id: HANCESTRO:0452
 name: Emirati
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Arab Emirates
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates ! isDemonymOf United Arab Emirates
 
 [Term]
 id: HANCESTRO:0453
 name: Yemeni
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Yemen
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen ! isDemonymOf Yemen
 
 [Term]
 id: HANCESTRO:0454
 name: Aruban
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Aruba
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba ! isDemonymOf Aruba
 
 [Term]
 id: HANCESTRO:0455
 name: Christmas Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Christmas:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Christmas Island
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Christmas:Island ! isDemonymOf Christmas Island
 
 [Term]
 id: HANCESTRO:0456
 name: Cocos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cocos (Keeling) Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands ! isDemonymOf Cocos (Keeling) Islands
 
 [Term]
 id: HANCESTRO:0457
 name: Curacaoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Curacao
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao ! isDemonymOf Curacao
 
 [Term]
 id: HANCESTRO:0458
 name: Kosovar
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kosovo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo ! isDemonymOf Kosovo
 
 [Term]
 id: HANCESTRO:0459
 name: Northern Mariana Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Northern Mariana Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands ! isDemonymOf Northern Mariana Islands
 
 [Term]
 id: HANCESTRO:0460
 name: South Sudanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Sudan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Sudan ! isDemonymOf South Sudan
 
 [Term]
 id: HANCESTRO:0461
 name: Syrian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Syria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria ! isDemonymOf Syria
 
 [Term]
 id: HANCESTRO:0462
 name: British
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 United:Kingdom {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Kingdom
+relationship: HANCESTRO:0330 United:Kingdom ! isDemonymOf United Kingdom
 
 [Term]
 id: HANCESTRO:0463
 name: American
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 United:States {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 United:States ! isDemonymOf United States
 
 [Term]
 id: HANCESTRO:0464
 name: American Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 American:Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf American Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 American:Samoa ! isDemonymOf American Samoa
 
 [Term]
 id: HANCESTRO:0465
 name: Cook Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cook:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cook Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cook:Islands ! isDemonymOf Cook Islands
 
 [Term]
 id: HANCESTRO:0466
 name: Fijian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Fiji
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji ! isDemonymOf Fiji
 
 [Term]
 id: HANCESTRO:0467
 name: French Polynesian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Polynesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Polynesia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Polynesia ! isDemonymOf French Polynesia
 
 [Term]
 id: HANCESTRO:0468
 name: Guamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guam
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam ! isDemonymOf Guam
 
 [Term]
 id: HANCESTRO:0469
 name: I-Kiribati
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kiribati
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati ! isDemonymOf Kiribati
 
 [Term]
 id: HANCESTRO:0470
 name: Marshallese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Marshall:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Marshall Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Marshall:Islands ! isDemonymOf Marshall Islands
 
 [Term]
 id: HANCESTRO:0471
 name: Micronesian
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Micronesia (Federated States of)
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia ! isDemonymOf Micronesia (Federated States of)
 
 [Term]
 id: HANCESTRO:0472
 name: Nauruan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nauru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru ! isDemonymOf Nauru
 
 [Term]
 id: HANCESTRO:0473
 name: New Caledonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Caledonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Caledonia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 New:Caledonia ! isDemonymOf New Caledonia
 
 [Term]
 id: HANCESTRO:0474
 name: Niuean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niue
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue ! isDemonymOf Niue
 
 [Term]
 id: HANCESTRO:0475
 name: Palauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau ! isDemonymOf Palau
 
 [Term]
 id: HANCESTRO:0476
 name: Papua New Guinean
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Papua New Guinea
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea ! isDemonymOf Papua New Guinea
 
 [Term]
 id: HANCESTRO:0477
 name: Pitcairn Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Pitcairn:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pitcairn Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Pitcairn:Islands ! isDemonymOf Pitcairn Islands
 
 [Term]
 id: HANCESTRO:0478
 name: Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa ! isDemonymOf Samoa
 
 [Term]
 id: HANCESTRO:0479
 name: Solomon Islander
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 Solomon:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Solomon Islands
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 Solomon:Islands ! isDemonymOf Solomon Islands
 
 [Term]
 id: HANCESTRO:0480
 name: Tokelauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tokelau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau ! isDemonymOf Tokelau
 
 [Term]
 id: HANCESTRO:0481
 name: Tongan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tonga
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga ! isDemonymOf Tonga
 
 [Term]
 id: HANCESTRO:0482
 name: Tuvaluan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tuvalu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu ! isDemonymOf Tuvalu
 
 [Term]
 id: HANCESTRO:0483
 name: Ni-Vanuato
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vanuatu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu ! isDemonymOf Vanuatu
 
 [Term]
 id: HANCESTRO:0484
 name: Wallis and Futuna Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Wallis and Futuna
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna ! isDemonymOf Wallis and Futuna
 
 [Term]
 id: HANCESTRO:0485
 name: Bangladeshi
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bangladesh
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh ! isDemonymOf Bangladesh
 
 [Term]
 id: HANCESTRO:0486
 name: Bhutanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bhutan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan ! isDemonymOf Bhutan
 
 [Term]
 id: HANCESTRO:0487
 name: Indian
 synonym: "Asian Indian" EXACT []
 synonym: "Indian Asian" EXACT []
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/India {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf India
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/India ! isDemonymOf India
 
 [Term]
 id: HANCESTRO:0488
 name: Maldivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Maldives
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives ! isDemonymOf Maldives
 
 [Term]
 id: HANCESTRO:0489
 name: Nepalese
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nepal
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal ! isDemonymOf Nepal
 
 [Term]
 id: HANCESTRO:0490
 name: Pakistani
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pakistan
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan ! isDemonymOf Pakistan
 
 [Term]
 id: HANCESTRO:0491
 name: Sri Lankan
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 Sri:Lanka {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sri Lanka
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 Sri:Lanka ! isDemonymOf Sri Lanka
 
 [Term]
 id: HANCESTRO:0492
 name: Bruneian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brunei
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei ! isDemonymOf Brunei
 
 [Term]
 id: HANCESTRO:0493
 name: Cambodian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cambodia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia ! isDemonymOf Cambodia
 
 [Term]
 id: HANCESTRO:0494
 name: Indonesian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Indonesia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia ! isDemonymOf Indonesia
 
 [Term]
 id: HANCESTRO:0495
 name: Lao
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Laos
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos ! isDemonymOf Laos
 
 [Term]
 id: HANCESTRO:0496
 name: Malaysian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malaysia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia ! isDemonymOf Malaysia
 
 [Term]
 id: HANCESTRO:0497
 name: Burmese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Myanmar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar ! isDemonymOf Myanmar
 
 [Term]
 id: HANCESTRO:0498
 name: Filipino
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Philippines
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines ! isDemonymOf Philippines
 
 [Term]
 id: HANCESTRO:0500
 name: Thai
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Thailand
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand ! isDemonymOf Thailand
 
 [Term]
 id: HANCESTRO:0501
 name: Timorese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 East:Timor {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf East Timor
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 East:Timor ! isDemonymOf East Timor
 
 [Term]
 id: HANCESTRO:0502
 name: Vietnamese
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vietnam
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam ! isDemonymOf Vietnam
 
 [Term]
 id: HANCESTRO:0503
 name: Cameroonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cameroon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon ! isDemonymOf Cameroon
 
 [Term]
 id: HANCESTRO:0504
 name: Cape Verdean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Cape:Verde {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cape Verde
+relationship: HANCESTRO:0330 Cape:Verde ! isDemonymOf Cape Verde
 
 [Term]
 id: HANCESTRO:0505
 name: Chadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chad
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad ! isDemonymOf Chad
 
 [Term]
 id: HANCESTRO:0506
 name: Ethiopian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ethiopia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia ! isDemonymOf Ethiopia
 
 [Term]
 id: HANCESTRO:0507
 name: Kenyan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kenya
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya ! isDemonymOf Kenya
 
 [Term]
 id: HANCESTRO:0508
 name: Liberian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liberia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia ! isDemonymOf Liberia
 
 [Term]
 id: HANCESTRO:0509
 name: Malagasy
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Madagascar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar ! isDemonymOf Madagascar
 
 [Term]
 id: HANCESTRO:0510
 name: Mauritanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritania
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania ! isDemonymOf Mauritania
 
 [Term]
 id: HANCESTRO:0511
 name: Mauritian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritius
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius ! isDemonymOf Mauritius
 
 [Term]
 id: HANCESTRO:0512
 name: Mahoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mayotte
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte ! isDemonymOf Mayotte
 
 [Term]
 id: HANCESTRO:0513
 name: Namibian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Namibia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia ! isDemonymOf Namibia
 
 [Term]
 id: HANCESTRO:0514
 name: Sao Tomean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf São Tomé and Príncipe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe ! isDemonymOf São Tomé and Príncipe
 
 [Term]
 id: HANCESTRO:0515
 name: Senegalese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Senegal
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal ! isDemonymOf Senegal
 
 [Term]
 id: HANCESTRO:0516
 name: Seychellois
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Seychelles
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles ! isDemonymOf Seychelles
 
 [Term]
 id: HANCESTRO:0517
 name: Sierra Leonean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Sierra:Leone {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sierra Leone
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Sierra:Leone ! isDemonymOf Sierra Leone
 
 [Term]
 id: HANCESTRO:0518
 name: Somali
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Somalia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia ! isDemonymOf Somalia
 
 [Term]
 id: HANCESTRO:0519
 name: South African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Africa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Africa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Africa ! isDemonymOf South Africa
 
 [Term]
 id: HANCESTRO:0520
 name: St. Helenian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Helena {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Helena
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Helena ! isDemonymOf Saint Helena
 
 [Term]
 id: HANCESTRO:0521
 name: Ugandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uganda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda ! isDemonymOf Uganda
 
 [Term]
 id: HANCESTRO:0522
 name: Angolan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Angola
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola ! isDemonymOf Angola
 
 [Term]
 id: HANCESTRO:0523
 name: Beninese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Benin
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin ! isDemonymOf Benin
 
 [Term]
 id: HANCESTRO:0524
 name: Motswana
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Botswana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana ! isDemonymOf Botswana
 
 [Term]
 id: HANCESTRO:0525
 name: Burkinabe
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Burkina:Faso {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burkina Faso
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Burkina:Faso ! isDemonymOf Burkina Faso
 
 [Term]
 id: HANCESTRO:0526
 name: Burundian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burundi
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi ! isDemonymOf Burundi
 
 [Term]
 id: HANCESTRO:0527
 name: Central African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Central African Republic
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic ! isDemonymOf Central African Republic
 
 [Term]
 id: HANCESTRO:0528
 name: Comoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Comoros
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros ! isDemonymOf Comoros
 
 [Term]
 id: HANCESTRO:0529
 name: Congolese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Democratic Republic of the Congo
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of the Congo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo ! isDemonymOf Democratic Republic of the Congo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo ! isDemonymOf Republic of the Congo
 
 [Term]
 id: HANCESTRO:0530
 name: Ivoirian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Ivory:Coast {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Côte d'Ivoire
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Ivory:Coast ! isDemonymOf Côte d'Ivoire
 
 [Term]
 id: HANCESTRO:0531
 name: Djiboutian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Djibouti
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti ! isDemonymOf Djibouti
 
 [Term]
 id: HANCESTRO:0532
 name: Equatorial Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Equatorial:Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Equatorial Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Equatorial:Guinea ! isDemonymOf Equatorial Guinea
 
 [Term]
 id: HANCESTRO:0533
 name: Eritrean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Eritrea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea ! isDemonymOf Eritrea
 
 [Term]
 id: HANCESTRO:0534
 name: Gabonese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gabon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon ! isDemonymOf Gabon
 
 [Term]
 id: HANCESTRO:0535
 name: Gambian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 The:Gambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Gambia
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 The:Gambia ! isDemonymOf The Gambia
 
 [Term]
 id: HANCESTRO:0536
 name: Ghanaian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ghana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana ! isDemonymOf Ghana
 
 [Term]
 id: HANCESTRO:0537
 name: Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea ! isDemonymOf Guinea
 
 [Term]
 id: HANCESTRO:0538
 name: Bissau-Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Guinea:Bissau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea-Bissau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Guinea:Bissau ! isDemonymOf Guinea-Bissau
 
 [Term]
 id: HANCESTRO:0539
 name: Mosotho
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lesotho
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho ! isDemonymOf Lesotho
 
 [Term]
 id: HANCESTRO:0540
 name: Malawian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malawi
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi ! isDemonymOf Malawi
 
 [Term]
 id: HANCESTRO:0541
 name: Malian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mali
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali ! isDemonymOf Mali
 
 [Term]
 id: HANCESTRO:0542
 name: Mozambican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mozambique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique ! isDemonymOf Mozambique
 
 [Term]
 id: HANCESTRO:0543
 name: Nigerien
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niger
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger ! isDemonymOf Niger
 
 [Term]
 id: HANCESTRO:0544
 name: Nigerian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nigeria
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria ! isDemonymOf Nigeria
 
 [Term]
 id: HANCESTRO:0545
 name: Rwandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Rwanda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda ! isDemonymOf Rwanda
 
 [Term]
 id: HANCESTRO:0546
 name: Swazi
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Swaziland
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland ! isDemonymOf Swaziland
 
 [Term]
 id: HANCESTRO:0547
 name: Togolese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Togo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo ! isDemonymOf Togo
 
 [Term]
 id: HANCESTRO:0548
 name: Tanzanian
 is_a: HANCESTRO:0011 ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tanzania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania ! isDemonymOf Tanzania
 
 [Term]
 id: HANCESTRO:0549
 name: Zambian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zambia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia ! isDemonymOf Zambia
 
 [Term]
 id: HANCESTRO:0550
 name: Zimbabweian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zimbabwe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe ! isDemonymOf Zimbabwe
 
 [Term]
 id: HANCESTRO:0551
@@ -2621,67 +2503,99 @@ property_value: IAO:0000119 "PMID:31626772" xsd:string
 id: Holy:See
 name: Holy See
 xref: GAZ:00003103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: Hong:Kong
 name: Hong Kong
 synonym: "China, Hong Kong SAR" EXACT []
 xref: GAZ:00003203
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: Ivory:Coast
 name: Côte d'Ivoire
 synonym: "Ivory Coast" EXACT []
 xref: GAZ:00000906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Marshall:Islands
 name: Marshall Islands
 xref: GAZ:00007161
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
+
+[Term]
+id: Middle:Africa
+name: Middle Africa
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: NCIT:C25464
+name: Country
+def: "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states." []
+is_a: COB:0000032 ! geographical location
+relationship: RO:0001025 HANCESTRO:0002 {all_only="true"} ! located in region
 
 [Term]
 id: Netherlands:Antilles
 name: Netherlands Antilles
 xref: GAZ:00004019
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: New:Caledonia
 name: New Caledonia
 xref: GAZ:00005206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: New:Zealand
 name: New Zealand
 xref: GAZ:00000469
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: Norfolk:Island
 name: Norfolk Island
 xref: GAZ:00005913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: North:Korea
 name: North Korea
 synonym: "Democratic People's Republic of Korea" EXACT []
 xref: GAZ:00002801
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
+
+[Term]
+id: Northern:Africa
+name: Northern Africa
+xref: GAZ:00000555
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Northern:America
+name: Northern America
+xref: GAZ:00000458
+is_a: GAZ:00000013 ! continent
+
+[Term]
+id: Northern:Europe
+name: Northern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: OBI:0000181
@@ -2716,24 +2630,24 @@ id: Palestinian:territories
 name: Palestinian Territories
 synonym: "Occupied Palestinian Territory" EXACT []
 xref: GAZ:00002475
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Pitcairn:Islands
 name: Pitcairn Islands
 synonym: "Pitcairn, Henderson, Ducie and Oeno Islands" EXACT []
 xref: GAZ:00005867
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 property_value: IAO:0000118 "Pitcairn" xsd:string
 
 [Term]
 id: Puerto:Rico
 name: Puerto Rico
 xref: GAZ:00006935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 property_value: IAO:0000118 "Commonwealth of Puerto Rico" xsd:string
 
 [Term]
@@ -2746,1487 +2660,1611 @@ id: Saint:Helena
 name: Saint Helena
 synonym: "St. Helena" EXACT []
 xref: GAZ:00000849
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Saint:Lucia
 name: Saint Lucia
 xref: GAZ:00006909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: Saint:Martin
 name: Saint Martin
 xref: GAZ:00005841
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: San:Marino
 name: San Marino
 xref: GAZ:00003102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: Saudi:Arabia
 name: Saudi Arabia
 xref: GAZ:00005279
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Sierra:Leone
 name: Sierra Leone
 xref: GAZ:00000914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Sint:Maarten
 name: Sint Maarten
 xref: GAZ:00012579
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: Solomon:Islands
 name: Solomon Islands
 xref: GAZ:00005275
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
+
+[Term]
+id: South-Eastern:Asia
+name: South-Eastern Asia
+xref: GAZ:00000559
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: South-central:Asia
+name: South-Central Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Africa
 name: South Africa
 xref: GAZ:00000553
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
+
+[Term]
+id: South:Asia
+name: South Asia
+xref: GAZ:00002472
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Korea
 name: South Korea
 synonym: "Republic of Korea" EXACT []
 xref: GAZ:00002802
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: South:Sudan
 name: South Sudan
 xref: GAZ:00233439
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
+
+[Term]
+id: Southern:Africa
+name: Southern Africa
+xref: GAZ:00000553
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Southern:Europe
+name: Southern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Sri:Lanka
 name: Sri Lanka
 xref: GAZ:00003924
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: The:Bahamas
 name: The Bahamas
 synonym: "Bahamas" EXACT []
 xref: GAZ:00002733
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: The:Gambia
 name: The Gambia
 synonym: "Gambia" EXACT []
 xref: GAZ:00000907
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: United:Kingdom
 name: United Kingdom
 synonym: "U.K." EXACT []
 xref: GAZ:00002637
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: United:States
 name: United States
 synonym: "United States of America" EXACT []
 xref: GAZ:00002459
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 property_value: IAO:0000118 "U.S." xsd:string
+
+[Term]
+id: Western:Africa
+name: Western Africa
+xref: GAZ:00000554
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Western:Asia
+name: Western Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Western:Europe
+name: Western Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Western:Sahara
 name: Western Sahara
 xref: GAZ:00000564
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Afghanistan
 name: Afghanistan
 xref: GAZ:00006882
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
+
+[Term]
+id: http://dbpedia.org/resource/Africa
+name: Africa
+xref: GAZ:00000457
+is_a: GAZ:00000013 ! continent
+disjoint_from: http://dbpedia.org/resource/Asia ! Asia
 
 [Term]
 id: http://dbpedia.org/resource/Albania
 name: Albania
 xref: GAZ:00002953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Algeria
 name: Algeria
 xref: GAZ:00000563
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Andorra
 name: Andorra
 xref: GAZ:00002948
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Angola
 name: Angola
 xref: GAZ:00001095
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Anguilla
 name: Anguilla
 xref: GAZ:00009159
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Antigua_and_Barbuda
 name: Antigua and Barbuda
 xref: GAZ:00006883
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Argentina
 name: Argentina
 xref: GAZ:00002928
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Armenia
 name: Armenia
 xref: GAZ:00004094
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Aruba
 name: Aruba
 xref: GAZ:00004025
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
+
+[Term]
+id: http://dbpedia.org/resource/Asia
+name: Asia
+xref: GAZ:00000465
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Australia
 name: Australia
 xref: GAZ:00000463
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Austria
 name: Austria
 xref: GAZ:00002942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Azerbaijan
 name: Azerbaijan
 xref: GAZ:00004941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bahrain
 name: Bahrain
 xref: GAZ:00005281
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bangladesh
 name: Bangladesh
 xref: GAZ:00003750
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Barbados
 name: Barbados
 xref: GAZ:00001251
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Belarus
 name: Belarus
 xref: GAZ:00006886
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belgium
 name: Belgium
 xref: GAZ:00002938
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belize
 name: Belize
 xref: GAZ:00002934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Benin
 name: Benin
 xref: GAZ:00000904
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Bermuda
 name: Bermuda
 xref: GAZ:00001264
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Bhutan
 name: Bhutan
 xref: GAZ:00003920
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bolivia
 name: Bolivia
 xref: GAZ:00002511
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Bosnia_and_Herzegovina
 name: Bosnia and Herzegovina
 xref: GAZ:00006887
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Botswana
 name: Botswana
 xref: GAZ:00001097
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Brazil
 name: Brazil
 xref: GAZ:00002828
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/British_Virgin_Islands
 name: British Virgin Islands
 xref: GAZ:00003961
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Brunei
 name: Brunei
 synonym: "Brunei Darussalam" EXACT []
 xref: GAZ:00003901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bulgaria
 name: Bulgaria
 xref: GAZ:00002950
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Burundi
 name: Burundi
 xref: GAZ:00001090
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Cambodia
 name: Cambodia
 xref: GAZ:00006888
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cameroon
 name: Cameroon
 xref: GAZ:00001093
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Canada
 name: Canada
 xref: GAZ:00002560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
+
+[Term]
+id: http://dbpedia.org/resource/Caribbean
+name: Caribbean
+is_a: HANCESTRO:0002 ! region
+disjoint_from: Central:America ! Central America
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Central_African_Republic
 name: Central African Republic
 xref: GAZ:00001089
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chad
 name: Chad
 xref: GAZ:00000586
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chile
 name: Chile
 xref: GAZ:00002825
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/China
 name: China
 xref: GAZ:00002845
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cocos_(Keeling)_Islands
 name: Cocos (Keeling) Islands
 xref: GAZ:00009721
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Colombia
 name: Colombia
 xref: GAZ:00002929
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Comoros
 name: Comoros
 xref: GAZ:00005820
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Croatia
 name: Croatia
 xref: GAZ:00002719
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Cuba
 name: Cuba
 xref: GAZ:00003762
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Curacao
 name: Curacao
 xref: GAZ:00012582
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Cyprus
 name: Cyprus
 xref: GAZ:00453362
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Democratic_Republic_of_the_Congo
 name: Democratic Republic of the Congo
 xref: GAZ:00001086
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Denmark
 name: Denmark
 xref: GAZ:00002635
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Djibouti
 name: Djibouti
 xref: GAZ:00000582
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Dominica
 name: Dominica
 xref: GAZ:00006890
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Ecuador
 name: Ecuador
 xref: GAZ:00002912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Egypt
 name: Egypt
 xref: GAZ:00003934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Eritrea
 name: Eritrea
 xref: GAZ:00000581
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Estonia
 name: Estonia
 xref: GAZ:00002959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ethiopia
 name: Ethiopia
 xref: GAZ:00000567
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Europe
+name: Europe
+xref: GAZ:00000464
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Federated_States_of_Micronesia
 name: Micronesia (Federated States of)
 xref: GAZ:00006897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Fiji
 name: Fiji
 xref: GAZ:00006891
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Finland
 name: Finland
 xref: GAZ:00002937
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/France
 name: France
 xref: GAZ:00002940
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Gabon
 name: Gabon
 xref: GAZ:00001092
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Germany
 name: Germany
 xref: GAZ:00002646
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ghana
 name: Ghana
 xref: GAZ:00000908
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Gibraltar
 name: Gibraltar
 xref: GAZ:00003987
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greece
 name: Greece
 xref: GAZ:00002945
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greenland
 name: Greenland
 xref: GAZ:00001507
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Grenada
 name: Grenada
 xref: GAZ:02000573
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guadeloupe
 name: Guadeloupe
 xref: GAZ:00067135
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guam
 name: Guam
 xref: GAZ:00006933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Guatemala
 name: Guatemala
 xref: GAZ:00002936
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Guinea
 name: Guinea
 xref: GAZ:00000909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Guyana
 name: Guyana
 xref: GAZ:00002522
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Haiti
 name: Haiti
 xref: GAZ:00003953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Honduras
 name: Honduras
 xref: GAZ:00002894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Hungary
 name: Hungary
 xref: GAZ:00002952
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Iceland
 name: Iceland
 xref: GAZ:00000843
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/India
 name: India
 xref: GAZ:00002839
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Indonesia
 name: Indonesia
 xref: GAZ:00003727
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iran
 name: Iran
 synonym: "Iran (Islamic Republic of)" EXACT []
 xref: GAZ:00004474
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iraq
 name: Iraq
 xref: GAZ:00004483
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Isle_of_Man
 name: Isle of Man
 xref: GAZ:00052477
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Israel
 name: Israel
 xref: GAZ:00002476
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Italy
 name: Italy
 xref: GAZ:00002650
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Jamaica
 name: Jamaica
 xref: GAZ:00003781
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Japan
 name: Japan
 xref: GAZ:00002747
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Jordan
 name: Jordan
 xref: GAZ:00002473
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kazakhstan
 name: Kazakhstan
 xref: GAZ:00004999
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kenya
 name: Kenya
 xref: GAZ:00001101
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Kiribati
 name: Kiribati
 xref: GAZ:00006894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Kosovo
 name: Kosovo
 xref: GAZ:00011337
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Kuwait
 name: Kuwait
 xref: GAZ:00005285
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kyrgyzstan
 name: Kyrgyzstan
 xref: GAZ:00006893
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Laos
 name: Laos
 synonym: "Lao People's Democratic Republic" EXACT []
 xref: GAZ:00006889
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
+
+[Term]
+id: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
+name: Latin America and the Caribbean
+xref: GAZ:00000459
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Latvia
 name: Latvia
 xref: GAZ:00002958
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lebanon
 name: Lebanon
 xref: GAZ:00002478
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Lesotho
 name: Lesotho
 xref: GAZ:00001098
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liberia
 name: Liberia
 xref: GAZ:00000911
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Libya
 name: Libya
 synonym: "Libyan Arab Jamahiriya" EXACT []
 xref: GAZ:00000566
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liechtenstein
 name: Liechtenstein
 xref: GAZ:00003858
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lithuania
 name: Lithuania
 xref: GAZ:00002960
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Luxembourg
 name: Luxembourg
 xref: GAZ:00002947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Macau
 name: Macau
 synonym: "China, Macao SAR" EXACT []
 xref: GAZ:00003202
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Madagascar
 name: Madagascar
 xref: GAZ:00001108
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malawi
 name: Malawi
 xref: GAZ:00001105
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malaysia
 name: Malaysia
 xref: GAZ:00003902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Maldives
 name: Maldives
 xref: GAZ:00006896
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Mali
 name: Mali
 xref: GAZ:00000584
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malta
 name: Malta
 xref: GAZ:00004017
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Martinique
 name: Martinique
 xref: GAZ:00003947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Mauretania
 name: Mauritania
 synonym: "Mauretania" EXACT []
 xref: GAZ:00000583
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mauritius
 name: Mauritius
 xref: GAZ:00003745
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mayotte
 name: Mayotte
 xref: GAZ:00003943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Melanesia
+name: Melanesia
+xref: GAZ:00005860
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Mexico
 name: Mexico
 xref: GAZ:00002852
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
+
+[Term]
+id: http://dbpedia.org/resource/Micronesia
+name: Micronesia
+xref: GAZ:00005862
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Moldova
 name: Moldova
 synonym: "Republic of Moldova" EXACT []
 xref: GAZ:00003897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Monaco
 name: Monaco
 xref: GAZ:00003857
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Mongolia
 name: Mongolia
 xref: GAZ:00008744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Montenegro
 name: Montenegro
 xref: GAZ:00006898
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Montserrat
 name: Montserrat
 xref: GAZ:00003988
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Morocco
 name: Morocco
 xref: GAZ:00000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mozambique
 name: Mozambique
 xref: GAZ:00001100
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Myanmar
 name: Myanmar
 synonym: "Burma" EXACT []
 xref: GAZ:00006899
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Namibia
 name: Namibia
 xref: GAZ:00001096
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nauru
 name: Nauru
 xref: GAZ:00006900
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Nepal
 name: Nepal
 xref: GAZ:00004399
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Netherlands
 name: Netherlands
 xref: GAZ:00001549
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Nicaragua
 name: Nicaragua
 xref: GAZ:00002978
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Niger
 name: Niger
 xref: GAZ:00000585
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nigeria
 name: Nigeria
 xref: GAZ:00000912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Niue
 name: Niue
 xref: GAZ:00006902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 property_value: IAO:0000118 "Niue Fekai" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Northern_Mariana_Islands
 name: Northern Mariana Islands
 xref: GAZ:00003958
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Norway
 name: Norway
 xref: GAZ:00002699
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 property_value: IAO:0000118 "Kingdom of Norway" xsd:string
+
+[Term]
+id: http://dbpedia.org/resource/Oceania
+name: Oceania
+xref: GAZ:00000468
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Oman
 name: Oman
 xref: GAZ:00005283
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Pakistan
 name: Pakistan
 xref: GAZ:00005246
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Palau
 name: Palau
 xref: GAZ:00006905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Panama
 name: Panama
 xref: GAZ:00002892
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Papua_New_Guinea
 name: Papua New Guinea
 xref: GAZ:00003922
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Paraguay
 name: Paraguay
 xref: GAZ:00002933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Peru
 name: Peru
 xref: GAZ:00002932
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Philippines
 name: Philippines
 xref: GAZ:00004525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 property_value: IAO:0000118 "The Philippines" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Poland
 name: Poland
 xref: GAZ:00002939
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
+
+[Term]
+id: http://dbpedia.org/resource/Polynesia
+name: Polynesia
+xref: GAZ:00005861
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Portugal
 name: Portugal
 xref: GAZ:00002944
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 property_value: IAO:0000118 "Portugese Republic" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Qatar
 name: Qatar
 xref: GAZ:00005286
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Ireland
 name: Republic of Ireland
 synonym: "Ireland" EXACT []
 xref: GAZ:00002943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Macedonia
 name: Republic of Macedonia
 synonym: "The former Yugoslav Republic of Macedonia" EXACT []
 xref: GAZ:00006895
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_the_Congo
 name: Republic of the Congo
 synonym: "Congo" EXACT []
 xref: GAZ:00001088
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Romania
 name: Romania
 xref: GAZ:00002951
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Russia
 name: Russia
 synonym: "Russian Federation" EXACT []
 xref: GAZ:00002721
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Rwanda
 name: Rwanda
 xref: GAZ:00001087
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Réunion
 name: Réunion
 xref: GAZ:00053746
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Kitts_and_Nevis
 name: Saint Kitts and Nevis
 xref: GAZ:00006906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Pierre_and_Miquelon
 name: Saint Pierre and Miquelon
 synonym: "Saint-Pierre-et-Miquelon" EXACT []
 xref: GAZ:00003942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines
 name: Saint Vincent and the Grenadines
 xref: GAZ:02000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Samoa
 name: Samoa
 xref: GAZ:00006910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
+
+[Term]
+id: http://dbpedia.org/resource/Scandinavia
+name: Scandinavia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: http://dbpedia.org/resource/Scotland
 name: Scotland
 xref: GAZ:00002639
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Senegal
 name: Senegal
 xref: GAZ:00000913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Serbia
 name: Serbia
 xref: GAZ:00002957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Seychelles
 name: Seychelles
 xref: GAZ:00005821
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Singapore
 name: Singapore
 xref: GAZ:00003923
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Slovakia
 name: Slovakia
 xref: GAZ:00002956
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Slovenia
 name: Slovenia
 xref: GAZ:00002955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Somalia
 name: Somalia
 xref: GAZ:00001104
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/SouthAmerica
+name: South America
+xref: GAZ:00000459
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Spain
 name: Spain
 xref: GAZ:00000591
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Sudan
 name: Sudan
 xref: GAZ:00000560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Suriname
 name: Suriname
 xref: GAZ:00002525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Swaziland
 name: Swaziland
 xref: GAZ:00001099
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Sweden
 name: Sweden
 xref: GAZ:00002729
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Switzerland
 name: Switzerland
 xref: GAZ:00002941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Syria
 name: Syria
 xref: GAZ:00002474
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/São_Tomé_and_Príncipe
 name: São Tomé and Príncipe
 xref: GAZ:00006927
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Taiwan
 name: Taiwan
 xref: GAZ:00005341
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tajikistan
 name: Tajikistan
 xref: GAZ:00006912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tanzania
 name: Tanzania
 synonym: "United Republic of Tanzania" EXACT []
 xref: GAZ:00001103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Thailand
 name: Thailand
 xref: GAZ:00003744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Togo
 name: Togo
 xref: GAZ:00000915
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Tokelau
 name: Tokelau
 xref: GAZ:00006914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Tonga
 name: Tonga
 xref: GAZ:00006916
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Trinidad_and_Tobago
 name: Trinidad and Tobago
 xref: GAZ:00003767
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tunisia
 name: Tunisia
 xref: GAZ:00000562
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Turkey
 name: Turkey
 xref: GAZ:00000558
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turkmenistan
 name: Turkmenistan
 xref: GAZ:00005018
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turks_and_Caicos_Islands
 name: Turks and Caicos Islands
 xref: GAZ:00003955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tuvalu
 name: Tuvalu
 xref: GAZ:00009715
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Uganda
 name: Uganda
 xref: GAZ:00001102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Ukraine
 name: Ukraine
 xref: GAZ:00002724
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/United_Arab_Emirates
 name: United Arab Emirates
 xref: GAZ:00005282
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/United_States_Virgin_Islands
 name: United States Virgin Islands
 synonym: "U.S. Virgin Islands" EXACT []
 xref: GAZ:00003959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Uruguay
 name: Uruguay
 xref: GAZ:00002930
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Uzbekistan
 name: Uzbekistan
 xref: GAZ:00004979
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Vanuatu
 name: Vanuatu
 xref: GAZ:00006918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Venezuela
 name: Venezuela
 xref: GAZ:00002931
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Vietnam
 name: Vietnam
 xref: GAZ:00003756
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Wallis_and_Futuna
 name: Wallis and Futuna
 synonym: "Wallis and Futuna Islands" EXACT []
 xref: GAZ:00007191
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Yemen
 name: Yemen
 xref: GAZ:00005284
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Zambia
 name: Zambia
 xref: GAZ:00001107
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Zimbabwe
 name: Zimbabwe
 xref: GAZ:00001106
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Typedef]
 id: BFO:0000050

--- a/hancestro-full.owl
+++ b/hancestro-full.owl
@@ -18,13 +18,13 @@
      xmlns:subsets="http://purl.obolibrary.org/obo/ro/subsets#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hancestro/hancestro-full.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro-full.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro-full.owl"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0004"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0304"/>
         <dc:description>Human ancestry ontology for the NHGRI GWAS Catalog</dc:description>
         <dc:title>Human Ancestry Ontology</dc:title>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
-        <owl:versionInfo>2023-10-13</owl:versionInfo>
+        <owl:versionInfo>2024-01-24</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -66,7 +66,6 @@
         <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -93,19 +92,14 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label>definition</rdfs:label>
-        <rdfs:label xml:lang="en">definition</rdfs:label>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">editor note</rdfs:label>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
     
 
 
@@ -121,8 +115,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">alternative term</rdfs:label>
         <rdfs:label>alternative_term</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -131,8 +123,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">definition source</rdfs:label>
         <rdfs:label>definition_source</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -658,12 +648,6 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <rdfs:label xml:lang="en">precedes</rdfs:label>
     </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000137 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000137"/>
     
 
 
@@ -2556,281 +2540,181 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Afghanistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Afghanistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid136"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006882</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Afghanistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid136">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid136"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
+        <rdfs:label>Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Albania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Albania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid139"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Albania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid139">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid139"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Algeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Algeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid142"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000563</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Algeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid142">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid142"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/American_Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/American_Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid145"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">American Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid145">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid145"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Andorra -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Andorra">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid148"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002948</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Andorra</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid148">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid148"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Angola -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Angola">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid151"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001095</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Angola</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid151">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid151"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Anguilla -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Anguilla">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid154"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009159</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Anguilla</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid154">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid154"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Antigua_and_Barbuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Antigua_and_Barbuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid157"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006883</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Antigua and Barbuda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid157">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid157"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Argentina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Argentina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid160"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002928</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Argentina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid160">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid160"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Armenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Armenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid163"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004094</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Armenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid163">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid163"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Aruba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Aruba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004025</oboInOwl:hasDbXref>
@@ -2839,826 +2723,536 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://dbpedia.org/resource/Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
+        <rdfs:label>Asia</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Australia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Australia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid167"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000463</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Australia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid167">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid167"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Austria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Austria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid170"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Austria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid170">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid170"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Azerbaijan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Azerbaijan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid173"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Azerbaijan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid173">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid173"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bahrain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bahrain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid176"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005281</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bahrain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid176">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid176"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bangladesh -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bangladesh">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid179"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003750</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bangladesh</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid179">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid179"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Barbados -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Barbados">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid182"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001251</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Barbados</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid182">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid182"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belarus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belarus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid185"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006886</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belarus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid185">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid185"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belgium -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belgium">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid188"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002938</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belgium</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid188">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid188"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belize -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belize">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid191"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belize</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid191">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid191"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Benin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Benin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid194"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000904</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Benin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid194">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid194"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bermuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bermuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001264</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bermuda</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bhutan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bhutan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid198"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003920</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bhutan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid198">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid198"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bolivia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bolivia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid201"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002511</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bolivia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid201">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid201"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bosnia_and_Herzegovina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bosnia_and_Herzegovina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid204"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006887</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bosnia and Herzegovina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid204">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid204"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Botswana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Botswana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid207"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001097</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Botswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid207">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid207"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brazil -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brazil">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid210"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002828</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Brazil</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid210">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid210"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/British_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/British_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid213"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003961</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">British Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid213">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid213"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brunei -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brunei">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid216"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003901</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Brunei Darussalam</oboInOwl:hasExactSynonym>
         <rdfs:label>Brunei</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid216">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid216"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bulgaria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bulgaria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid219"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002950</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bulgaria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid219">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid219"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burkina_Faso -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burkina_Faso">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid222"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burkina Faso</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid222">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid222"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burundi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burundi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid225"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001090</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burundi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid225">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid225"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cambodia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cambodia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid228"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006888</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cambodia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid228">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid228"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cameroon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cameroon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid231"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001093</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cameroon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid231">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid231"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Canada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Canada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00002560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Canada</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Canada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cape_Verde -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cape_Verde">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid235"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001227</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cape Verde</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid235">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid235"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Cayman_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cayman_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid238"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003986</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cayman Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid238">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid238"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Central_African_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Central_African_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001089</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Central African Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid241">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid241"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Central_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Central_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
+        <rdfs:label>Central America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Chad -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chad">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid244"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000586</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chad</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid244">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid244"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Channel_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Channel_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid247"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001539</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Channel Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid247">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid247"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Chile -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chile">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid250"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002825</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chile</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid250">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid250"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/China -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/China">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid253"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002845</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">China</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid253">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid253"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Christmas_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Christmas_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -3674,173 +3268,107 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Colombia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Colombia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid257"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002929</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Colombia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid257">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid257"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Comoros -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Comoros">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid260"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005820</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Comoros</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid260">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid260"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cook_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cook_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid263"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053798</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cook Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid263">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid263"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Costa_Rica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Costa_Rica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid266"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002901</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Costa Rica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid266">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid266"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Croatia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Croatia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid269"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002719</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Croatia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid269">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid269"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cuba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cuba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid272"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003762</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cuba</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid272">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid272"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Curacao -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Curacao">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012582</oboInOwl:hasDbXref>
@@ -3852,179 +3380,113 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Cyprus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cyprus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid276"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00453362</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cyprus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid276">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid276"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Czech_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Czech_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid279"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002954</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Czech Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid279">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid279"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Democratic_Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid282"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001086</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Democratic Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid282">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid282"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Denmark -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Denmark">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid286"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002635</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Denmark</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid286">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid286"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Djibouti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Djibouti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid289"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000582</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Djibouti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid289">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid289"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid292"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006890</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Dominica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid292">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid292"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominican_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominican_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003952</oboInOwl:hasDbXref>
@@ -4036,1329 +3498,852 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/East_Timor -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/East_Timor">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid296"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006913</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Timor-Leste</oboInOwl:hasExactSynonym>
         <rdfs:label>East Timor</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid296">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid296"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Eastern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Ecuador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ecuador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid299"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ecuador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid299">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid299"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Egypt -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Egypt">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid302"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Egypt</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid302">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid302"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/El_Salvador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/El_Salvador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid305"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">El Salvador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid305">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid305"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Equatorial_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Equatorial_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001091</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Equatorial Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid308">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid308"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Eritrea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Eritrea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid311"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000581</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Eritrea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid311">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid311"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Estonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Estonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002959</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Estonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid314">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid314"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ethiopia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ethiopia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid317"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000567</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ethiopia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid317">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid317"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
+        <rdfs:label>Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Faeroe_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Faeroe_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid320"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Faroe Islands</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00059206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Faeroe Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid320">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid320"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Falkland_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Falkland_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid323"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001412</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Falkland Islands (Malvinas)</oboInOwl:hasExactSynonym>
         <rdfs:label>Falkland Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid323">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid323"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Federated_States_of_Micronesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Federated_States_of_Micronesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid326"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006897</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Micronesia (Federated States of)</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid326">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid326"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Fiji -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Fiji">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid329"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006891</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Fiji</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid329">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid329"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Finland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Finland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid332"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002937</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Finland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid332">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid332"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/France -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/France">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid335"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002940</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">France</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid335">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid335"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Guiana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Guiana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid338"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002516</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Guiana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid338">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid338"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Polynesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Polynesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Polynesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid341">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid341"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gabon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gabon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid344"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001092</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gabon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid344">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid344"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Germany -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Germany">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002646</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Germany</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid347">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid347"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ghana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ghana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid350"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000908</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ghana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid350">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid350"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gibraltar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gibraltar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid353"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003987</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gibraltar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid353">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid353"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greece -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greece">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid356"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002945</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greece</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid356">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid356"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greenland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greenland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001507</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greenland</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greenland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Grenada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Grenada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid360"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000573</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Grenada</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid360">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid360"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guadeloupe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guadeloupe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid363"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00067135</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guadeloupe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid363">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid363"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid366"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid366">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid366"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guatemala -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guatemala">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid369"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002936</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guatemala</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid369">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid369"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid372"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid372">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid372"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea_Bissau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea_Bissau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid375"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea-Bissau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid375">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid375"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guyana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guyana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid378"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002522</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guyana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid378">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid378"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Haiti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Haiti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid381"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Haiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid381">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid381"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Holy_See -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Holy_See">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003103</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Holy See</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid384">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid384"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Honduras -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Honduras">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid387"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Honduras</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid387">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid387"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hong_Kong -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hong_Kong">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid390"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003203</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Hong Kong SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Hong Kong</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid390">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid390"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hungary -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hungary">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid393"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002952</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Hungary</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid393">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid393"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iceland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iceland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000843</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iceland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid396">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid396"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/India -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/India">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid399"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002839</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">India</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid399">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid399"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Indonesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Indonesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid402"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003727</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Indonesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid402">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid402"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iran -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iran">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid405"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004474</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Iran (Islamic Republic of)</oboInOwl:hasExactSynonym>
         <rdfs:label>Iran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid405">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid405"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iraq -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iraq">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid408"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004483</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iraq</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid408">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid408"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Isle_of_Man -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Isle_of_Man">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid411"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00052477</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Isle of Man</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid411">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid411"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Israel -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Israel">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid414"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002476</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Israel</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid414">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid414"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Italy -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Italy">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid417"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002650</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Italy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid417">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid417"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ivory_Coast -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ivory_Coast">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid420"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000906</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ivory Coast</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Côte d&apos;Ivoire</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid420">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid420"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jamaica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jamaica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid423"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003781</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jamaica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid423">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid423"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Japan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Japan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid426"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002747</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Japan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid426">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid426"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jordan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jordan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid429"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002473</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jordan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid429">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid429"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kazakhstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kazakhstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid432"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004999</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kazakhstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid432">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid432"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kenya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kenya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid435"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001101</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kenya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid435">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid435"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kiribati -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kiribati">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid438"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid438">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid438"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kosovo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kosovo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00011337</oboInOwl:hasDbXref>
@@ -5370,1234 +4355,837 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Kuwait -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kuwait">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid442"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005285</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kuwait</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid442">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid442"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kyrgyzstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kyrgyzstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid445"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006893</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kyrgyzstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid445">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid445"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Laos -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Laos">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006889</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Lao People&apos;s Democratic Republic</oboInOwl:hasExactSynonym>
         <rdfs:label>Laos</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid448">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid448"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Latin_America_and_the_Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Latvia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Latvia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid451"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002958</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Latvia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid451">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid451"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lebanon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lebanon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid454"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002478</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lebanon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid454">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid454"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lesotho -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lesotho">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid457"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001098</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lesotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid457">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid457"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liberia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liberia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid460"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000911</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liberia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid460">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid460"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Libya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Libya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid463"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000566</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Libyan Arab Jamahiriya</oboInOwl:hasExactSynonym>
         <rdfs:label>Libya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid463">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid463"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liechtenstein -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liechtenstein">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid466"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003858</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liechtenstein</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid466">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid466"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lithuania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lithuania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid469"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002960</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lithuania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid469">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid469"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Luxembourg -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Luxembourg">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid472"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Luxembourg</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid472">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid472"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Macau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Macau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid475"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003202</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Macao SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Macau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid475">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid475"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Madagascar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Madagascar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001108</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Madagascar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid478">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid478"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malawi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malawi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid481"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001105</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid481">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid481"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malaysia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malaysia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid484"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malaysia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid484">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid484"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Maldives -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Maldives">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid487"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006896</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Maldives</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid487">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid487"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mali -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mali">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid490"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000584</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid490">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid490"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malta -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malta">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid493"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004017</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malta</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid493">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid493"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Marshall_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Marshall_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid496"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007161</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Marshall Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid496">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid496"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Martinique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Martinique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid499"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Martinique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid499">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid499"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauretania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauretania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid502"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000583</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Mauretania</oboInOwl:hasExactSynonym>
         <rdfs:label>Mauritania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid502">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid502"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauritius -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauritius">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid505"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003745</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mauritius</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid505">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid505"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mayotte -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mayotte">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid508"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003943</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mayotte</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid508">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid508"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Melanesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Melanesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
+        <rdfs:label>Melanesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Mexico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mexico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid511"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002852</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mexico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid511">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid511"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Micronesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Micronesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
+        <rdfs:label>Micronesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Middle_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Middle_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Middle Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Moldova -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Moldova">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid514"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003897</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Moldova</oboInOwl:hasExactSynonym>
         <rdfs:label>Moldova</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid514">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid514"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Monaco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Monaco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid517"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003857</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Monaco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid517">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid517"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mongolia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mongolia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid520"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00008744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mongolia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid520">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid520"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montenegro -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montenegro">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid523"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006898</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montenegro</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid523">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid523"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montserrat -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montserrat">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid526"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003988</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montserrat</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid526">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid526"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Morocco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Morocco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid529"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Morocco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid529">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid529"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mozambique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mozambique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001100</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mozambique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid532">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid532"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Myanmar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Myanmar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid535"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006899</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Burma</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Myanmar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid535">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid535"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Namibia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Namibia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid538"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001096</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Namibia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid538">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid538"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nauru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nauru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid541"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006900</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nauru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid541">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid541"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nepal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nepal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid544"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004399</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nepal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid544">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid544"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid547"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001549</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid547">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid547"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands_Antilles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands_Antilles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid550"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004019</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands Antilles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid550">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid550"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Caledonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Caledonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid553"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Caledonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid553">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid553"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Zealand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Zealand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid556"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000469</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid556">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid556"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nicaragua -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nicaragua">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid559"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002978</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nicaragua</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid559">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid559"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niger -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niger">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid562"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000585</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niger</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid562">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid562"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nigeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nigeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid565"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nigeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid565">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid565"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niue -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niue">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid568"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Niue Fekai</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niue</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid568">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid568"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Norfolk_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norfolk_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid571"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norfolk Island</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid571">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid571"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/North_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/North_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid574"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002801</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Democratic People&apos;s Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>North Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid574">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid574"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
+        <rdfs:label>Northern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
+        <rdfs:label>Northern America</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Northern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Northern_Mariana_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Mariana_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003958</oboInOwl:hasDbXref>
@@ -6609,711 +5197,462 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Norway -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norway">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid579"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Kingdom of Norway</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002699</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norway</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid579">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid579"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Oceania -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Oceania">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
+        <rdfs:label>Oceania</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Oman -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Oman">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005283</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Oman</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid582">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid582"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pakistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pakistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid585"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005246</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Pakistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid585">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid585"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Palau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid588">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid588"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palestinian_territories -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palestinian_territories">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid591"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002475</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Occupied Palestinian Territory</oboInOwl:hasExactSynonym>
         <rdfs:label>Palestinian Territories</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid591">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid591"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Panama -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Panama">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid594"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002892</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Panama</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid594">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid594"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Papua_New_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Papua_New_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid597"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003922</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Papua New Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid597">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid597"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Paraguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Paraguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid600"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Paraguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid600">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid600"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Peru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Peru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid603"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002932</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Peru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid603">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid603"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Philippines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Philippines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid606"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>The Philippines</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00004525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Philippines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid606">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid606"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pitcairn_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pitcairn_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid609"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118 xml:lang="en">Pitcairn</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00005867</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Pitcairn, Henderson, Ducie and Oeno Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>Pitcairn Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid609">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid609"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Poland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Poland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid612"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002939</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Poland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid612">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid612"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Polynesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Polynesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
+        <rdfs:label>Polynesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Portugal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Portugal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid615"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Portugese Republic</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002944</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Portugal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid615">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid615"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Puerto_Rico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Puerto_Rico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Commonwealth of Puerto Rico</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Puerto Rico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid618">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid618"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Qatar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Qatar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid621"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005286</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Qatar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid621">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid621"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Ireland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Ireland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid624"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002943</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ireland</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Republic of Ireland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid624">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid624"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Macedonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Macedonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid627"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006895</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">The former Yugoslav Republic of Macedonia</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of Macedonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid627">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid627"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid630"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001088</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Congo</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid630">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid630"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Romania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Romania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid633"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002951</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Romania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid633">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid633"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Russia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Russia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid636"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002721</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Russian Federation</oboInOwl:hasExactSynonym>
         <rdfs:label>Russia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid636">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:allValuesFrom>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid636"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Rwanda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Rwanda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid642"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001087</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Rwanda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid642">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid642"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Réunion -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Réunion">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid645"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053746</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Réunion</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid645">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid645"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Helena -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Helena">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid648"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000849</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">St. Helena</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Helena</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid648">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid648"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Kitts_and_Nevis -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Kitts_and_Nevis">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid651"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006906</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Kitts and Nevis</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid651">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid651"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Lucia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Lucia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid654"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Lucia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid654">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid654"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Martin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Martin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005841</oboInOwl:hasDbXref>
@@ -7325,136 +5664,101 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Saint_Pierre_and_Miquelon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00003942</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Saint-Pierre-et-Miquelon</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Pierre and Miquelon</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Vincent and the Grenadines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid659">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid659"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid662"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid662">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid662"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/San_Marino -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/San_Marino">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid665"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">San Marino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid665">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid665"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saudi_Arabia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saudi_Arabia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid668"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005279</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saudi Arabia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid668">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid668"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Scandinavia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Scandinavia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Scandinavia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Scotland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Scotland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002639</oboInOwl:hasDbXref>
@@ -7466,146 +5770,91 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Senegal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Senegal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid672"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Senegal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid672">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid672"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Serbia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Serbia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid675"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Serbia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid675">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid675"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Seychelles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Seychelles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid678"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005821</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Seychelles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid678">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid678"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sierra_Leone -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sierra_Leone">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sierra Leone</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid681">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid681"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Singapore -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Singapore">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid684"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003923</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Singapore</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid684">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid684"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sint_Maarten -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sint_Maarten">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012579</oboInOwl:hasDbXref>
@@ -7617,174 +5866,171 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Slovakia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovakia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid688"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002956</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovakia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid688">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid688"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Slovenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid691"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid691">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid691"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Solomon_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Solomon_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid694"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005275</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Solomon Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid694">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid694"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Somalia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Somalia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid697"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001104</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Somalia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid697">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid697"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
+        <rdfs:label>South-Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-central_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-central_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>South-Central Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/SouthAmerica -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/SouthAmerica">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>South America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Africa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Africa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid700"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">South Africa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid700">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid700"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
+        <rdfs:label>South Asia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid703"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002802</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>South Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid703">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid703"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/South_Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00233439</oboInOwl:hasDbXref>
@@ -7793,209 +6039,163 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://dbpedia.org/resource/Southern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
+        <rdfs:label>Southern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Southern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Southern Europe</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Spain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Spain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid707"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000591</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Spain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid707">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid707"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sri_Lanka -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sri_Lanka">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid710"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003924</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sri Lanka</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid710">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid710"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid713"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid713">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid713"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Suriname -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Suriname">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid716"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Suriname</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid716">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid716"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Swaziland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Swaziland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid719"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001099</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Swaziland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid719">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid719"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sweden -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sweden">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid723"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002729</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sweden</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid723">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid723"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Switzerland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Switzerland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid726"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Switzerland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid726">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid726"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Syria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Syria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002474</oboInOwl:hasDbXref>
@@ -8007,38 +6207,27 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/São_Tomé_and_Príncipe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/São_Tomé_and_Príncipe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid730"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006927</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">São Tomé and Príncipe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid730">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid730"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Taiwan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Taiwan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005341</oboInOwl:hasDbXref>
@@ -8050,814 +6239,535 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Tajikistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tajikistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid734"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tajikistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid734">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid734"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tanzania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tanzania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid737"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001103</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">United Republic of Tanzania</oboInOwl:hasExactSynonym>
         <rdfs:label>Tanzania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid737">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid737"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Thailand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Thailand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid740"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Thailand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid740">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid740"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Bahamas -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Bahamas">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid743"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002733</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Bahamas</oboInOwl:hasExactSynonym>
         <rdfs:label>The Bahamas</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid743">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid743"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Gambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Gambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid746"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000907</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Gambia</oboInOwl:hasExactSynonym>
         <rdfs:label>The Gambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid746">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid746"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Togo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Togo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid749"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000915</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Togo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid749">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid749"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tokelau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tokelau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid752"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tokelau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid752">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid752"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tonga -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tonga">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid755"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006916</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tonga</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid755">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid755"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Trinidad_and_Tobago -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Trinidad_and_Tobago">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid758"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003767</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Trinidad and Tobago</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid758">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid758"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tunisia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tunisia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid761"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000562</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tunisia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid761">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid761"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkey -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkey">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid764"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000558</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkey</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid764">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid764"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkmenistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkmenistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid767"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005018</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkmenistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid767">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid767"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turks_and_Caicos_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turks_and_Caicos_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turks and Caicos Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid770">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid770"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tuvalu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tuvalu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid773"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009715</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tuvalu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid773">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid773"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uganda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uganda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid776"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uganda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid776">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid776"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ukraine -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ukraine">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid779"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002724</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ukraine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid779">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid779"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Arab_Emirates -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Arab_Emirates">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid782"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005282</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">United Arab Emirates</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid782">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid782"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Kingdom -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Kingdom">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid785"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002637</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.K.</oboInOwl:hasExactSynonym>
         <rdfs:label>United Kingdom</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid785">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid785"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <obo:IAO_0000118 xml:lang="en">U.S.</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002459</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>United States of America</oboInOwl:hasExactSynonym>
         <rdfs:label>United States</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid789"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003959</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.S. Virgin Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>United States Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid789">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid789"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uruguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uruguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid792"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002930</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uruguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid792">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid792"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uzbekistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uzbekistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid795"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004979</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uzbekistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid795">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid795"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vanuatu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vanuatu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid798"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vanuatu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid798">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid798"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Venezuela -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Venezuela">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid801"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002931</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Venezuela</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid801">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid801"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vietnam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vietnam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid804"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003756</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vietnam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid804">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid804"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Wallis_and_Futuna -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Wallis_and_Futuna">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid807"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007191</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Wallis and Futuna Islands</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Wallis and Futuna</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid807">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid807"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
+        <rdfs:label>Western Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Western_Sahara -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Western_Sahara">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid810"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000564</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Western Sahara</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid810">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid810"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Yemen -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Yemen">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid813"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005284</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Yemen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid813">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid813"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid816"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001107</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid816">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid816"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zimbabwe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zimbabwe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid819"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001106</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zimbabwe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid819">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid819"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cocos_(Keeling)_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cocos_(Keeling)_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -8873,27 +6783,16 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Georgia_(country) -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Georgia_(country)">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid823"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Georgia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid823">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid823"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9022,7 +6921,6 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://purl.obolibrary.org/obo/BFO_0000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
@@ -9035,64 +6933,9 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
             </owl:Restriction>
         </owl:disjointWith>
-        <obo:BFO_0000179>occurrent</obo:BFO_0000179>
-        <obo:BFO_0000180>Occurrent</obo:BFO_0000180>
         <obo:IAO_0000115 xml:lang="en">An entity that has temporal parts and that happens, unfolds or develops through time.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Occurrent doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process.</obo:IAO_0000116>
-        <obo:IAO_0000116>Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by &apos;spn[e]&apos; and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write &apos;spr[e]&apos; and `spl[e]&apos; respectively for the spread and spell of e, omitting mention of the frame.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">occurrent</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Occurrent doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000006"/>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget>Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by &apos;spn[e]&apos; and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write &apos;spr[e]&apos; and `spl[e]&apos; respectively for the spread and spell of e, omitting mention of the frame.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000012"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/077-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/108-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/079-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/108-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/079-001"/>
-    </owl:Axiom>
     
 
 
@@ -9107,7 +6950,6 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
         <obo:BFO_0000179>ic</obo:BFO_0000179>
         <obo:BFO_0000180>IndependentContinuant</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a chair</obo:IAO_0000112>
@@ -9173,48 +7015,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000141"/>
-        <obo:BFO_0000179>s-region</obo:BFO_0000179>
-        <obo:BFO_0000180>SpatialRegion</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Spatial regions do not participate in processes.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Spatial region doesn&apos;t have a closure axiom because the subclasses don&apos;t exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn&apos;t overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">spatial region</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Spatial region doesn&apos;t have a closure axiom because the subclasses don&apos;t exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn&apos;t overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000002"/>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/035-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/036-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/036-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/035-001"/>
-    </owl:Axiom>
     
 
 
@@ -9234,44 +7036,8 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:BFO_0000179>disposition</obo:BFO_0000179>
-        <obo:BFO_0000180>Disposition</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">an atom of element X has the disposition to decay to an atom of element Y</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">certain people have a predisposition to colon cancer</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">children are innately disposed to categorize objects in certain ways.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the cell wall is disposed to filter chemicals in endocytosis and exocytosis</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">disposition</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/062-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/063-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/063-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/062-002"/>
-    </owl:Axiom>
     
 
 
@@ -9286,45 +7052,9 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
-        <obo:BFO_0000179>realizable</obo:BFO_0000179>
-        <obo:BFO_0000180>RealizableEntity</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">the disposition of this piece of metal to conduct electricity.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the disposition of your blood to coagulate</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of your reproductive organs</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of this boundary to delineate where Utah and Colorado meet</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A specifically dependent continuant  that inheres in continuant  entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances.</obo:IAO_0000115>
-        <obo:IAO_0000600 xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">realizable entity</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/058-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/060-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/060-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/058-002"/>
-    </owl:Axiom>
     
 
 
@@ -9391,7 +7121,6 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
         <obo:BFO_0000179>sdc</obo:BFO_0000179>
         <obo:BFO_0000180>SpecificallyDependentContinuant</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key</obo:IAO_0000112>
@@ -9405,21 +7134,13 @@ For example, A and B may be gene products and binding of B by A positively regul
         <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of this hole.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the smell of this portion of mozzarella</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &amp;gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &amp;lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">b is a specifically dependent continuant = Def. b is a continuant &amp; there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">Specifically dependent continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. We&apos;re not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc.</obo:IAO_0000116>
-        <obo:IAO_0000602>(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] </obo:IAO_0000602>
         <obo:IAO_0000602>(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] </obo:IAO_0000602>
         <rdfs:comment xml:lang="en">A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">specifically dependent continuant</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget xml:lang="en">b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &amp;gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &amp;lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/131-004"/>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -9436,12 +7157,6 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/131-004"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
         <owl:annotatedTarget>(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] </owl:annotatedTarget>
         <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/050-003"/>
     </owl:Axiom>
@@ -9452,64 +7167,9 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <obo:BFO_0000179>role</obo:BFO_0000179>
-        <obo:BFO_0000180>Role</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the priest role</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a boundary to demarcate two neighboring administrative territories</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a building in serving as a military target</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a stone in marking a property boundary</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of subject in a clinical trial</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the student role</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role &amp; c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a role means: b is a realizable entity &amp; b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be&amp; b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">role</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">b is a role means: b is a realizable entity &amp; b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be&amp; b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/061-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/061-001"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000031 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <obo:BFO_0000179>gdc</obo:BFO_0000179>
-        <obo:BFO_0000180>GenericallyDependentContinuant</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the pdf file on your laptop, the pdf file that is a copy thereof on my laptop</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule.</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])</obo:IAO_0000115>
-        <obo:IAO_0000602>(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] </obo:IAO_0000602>
-        <rdfs:comment xml:lang="en">A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-        <rdfs:label xml:lang="en">generically dependent continuant</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget xml:lang="en">b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/074-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/074-001"/>
-    </owl:Axiom>
     
 
 
@@ -9517,29 +7177,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000034">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <obo:BFO_0000179>function</obo:BFO_0000179>
-        <obo:BFO_0000180>Function</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">the function of a hammer to drive in nails</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of a heart pacemaker to regulate the beating of a heart through electricity</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of amylase in saliva to break down starch into sugar</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">function</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/064-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/064-001"/>
-    </owl:Axiom>
     
 
 
@@ -9630,98 +7269,27 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
             </owl:Restriction>
         </owl:disjointWith>
-        <obo:BFO_0000179>immaterial</obo:BFO_0000179>
-        <obo:BFO_0000180>ImmaterialEntity</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10</obo:IAO_0000116>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">immaterial entity</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GEO_000000334 -->
+    <!-- http://purl.obolibrary.org/obo/COB_0000032 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000334">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000375"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000137"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label xml:lang="en">subcontinental land mass</rdfs:label>
-        <rdfs:label>subcontinental land mass</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000141"/>
+        <rdfs:label xml:lang="en">geographical location</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
+    <!-- http://purl.obolibrary.org/obo/GAZ_00000013 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-        <obo:IAO_0000111 xml:lang="en">geographical entity of astronomical body</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface).</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Matt Diller</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">William R. Hogan</obo:IAO_0000117>
-        <rdfs:comment xml:lang="en">Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.
-
-Generally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.</rdfs:comment>
-        <rdfs:comment xml:lang="en">Note that despite the word &apos;planetary&apos; in &apos;planetary surface&apos;, it refers generally to surface of dwarf planets, asteroids, moons, etc.</rdfs:comment>
-        <rdfs:comment xml:lang="en">We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.</rdfs:comment>
-        <rdfs:comment xml:lang="en">We note that the term &apos;geography&apos; is also applied to the Earth&apos;s moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  
-
-Thus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc.</rdfs:comment>
-        <rdfs:label xml:lang="en">geographical entity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000372 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000372">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
-        <obo:IAO_0000115 xml:lang="en">A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">François Modave</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Matt Diller</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">William R. Hogan</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">geographical region</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000374 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000374">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000375"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
         <obo:IAO_0000115>One of the large, unbroken masses of land into which the Earth&apos;s surface is divided.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>GAZ:00190836</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>major area</oboInOwl:hasExactSynonym>
         <rdfs:label>continent</rdfs:label>
-        <rdfs:label xml:lang="en">continent</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000375 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000375">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000372"/>
-        <rdfs:label xml:lang="en">land mass</rdfs:label>
-        <rdfs:label>land mass</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000391 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000391">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <obo:IAO_0000111 xml:lang="en">geopolitical organization</obo:IAO_0000111>
-        <obo:IAO_0000117 xml:lang="en">Amanda Hicks</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">geopoli organization</rdfs:label>
-        <rdfs:label>geopolitical organization</rdfs:label>
     </owl:Class>
     
 
@@ -9754,44 +7322,29 @@ Thus, we are attempting to define things generally enough that they could be reu
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000334"/>
-        <rdfs:subClassOf rdf:nodeID="genid895"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000115>Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>geographical area</oboInOwl:hasExactSynonym>
         <rdfs:label>region</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid895">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid895"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000391"/>
-        <rdfs:subClassOf rdf:nodeID="genid897"/>
         <obo:IAO_0000115>A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states.</obo:IAO_0000115>
         <obo:IAO_0000119>NCIT:C25464</obo:IAO_0000119>
-        <rdfs:label>country</rdfs:label>
+        <obo:IAO_0100001>http://purl.obolibrary.org/obo/NCIT_C25464</obo:IAO_0100001>
+        <rdfs:label>obsolete country</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid897">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid897"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10093,9 +7646,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
-        <rdfs:label>Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Africa"/>
+        <rdfs:label>obsolete Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10103,9 +7656,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
-        <rdfs:label>Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Asia"/>
+        <rdfs:label>obsolete Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10113,9 +7666,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0031 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
-        <rdfs:label>Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Europe"/>
+        <rdfs:label>obsolete Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10123,9 +7676,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
-        <rdfs:label>Oceania</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Oceania"/>
+        <rdfs:label>obsolete Oceania</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10133,9 +7686,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0033 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+        <rdfs:label>obsolete Latin America and the Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10143,9 +7696,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0034 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
-        <rdfs:label>Northern America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_America"/>
+        <rdfs:label>obsolete Northern America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10153,319 +7706,150 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0035 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid909"/>
-        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+        <rdfs:label>obsolete Eastern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid909">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid909"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid911"/>
-        <rdfs:label>Middle Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+        <rdfs:label>obsolete Middle Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid911">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid911"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid913"/>
-        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
-        <rdfs:label>Northern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+        <rdfs:label>obsolete Northern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid913">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid913"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0038 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid915"/>
-        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
-        <rdfs:label>Southern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+        <rdfs:label>obsolete Southern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid915">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid915"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0039 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid917"/>
-        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
-        <rdfs:label>Western Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+        <rdfs:label>obsolete Western Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid917">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid917"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0041 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid919"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label>South-Central Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+        <rdfs:label>obsolete South Central Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid919">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid919"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0042 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid922"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
-        <rdfs:label>South-Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+        <rdfs:label>obsolete South-Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid922">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid922"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid925"/>
-        <rdfs:label>Western Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+        <rdfs:label>obsolete Western Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid925">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid925"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0044 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid927"/>
-        <rdfs:label>Eastern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+        <rdfs:label>obsolete Eastern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid927">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid927"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0045 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid929"/>
-        <rdfs:label>Northern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+        <rdfs:label>obsolete Northern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid929">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid929"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid931"/>
-        <rdfs:label>Southern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+        <rdfs:label>obsolete Southern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid931">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid931"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0047 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid933"/>
-        <rdfs:label>Western Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+        <rdfs:label>obsolete Western Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid933">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid933"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid935"/>
-        <rdfs:label>Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+        <rdfs:label>obsolete Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid935">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid935"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0049 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid937"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>South America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+        <rdfs:label>obsolete South America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid937">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid937"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid939"/>
-        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
-        <rdfs:label>Central America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Central_America"/>
+        <rdfs:label>obsolete Central America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid939">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid939"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10473,103 +7857,54 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid941"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label>Australia/New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid941">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid941"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0052 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid943"/>
-        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
-        <rdfs:label>Melanesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+        <rdfs:label>obsolete Melanesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid943">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid943"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0053 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid945"/>
-        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
-        <rdfs:label>Micronesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+        <rdfs:label>obsolete Micronesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid945">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid945"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid947"/>
-        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
-        <rdfs:label>Polynesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+        <rdfs:label>obsolete Polynesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid947">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid947"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid949"/>
-        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+        <rdfs:label>obsolete Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid949">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid949"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10586,14 +7921,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0288 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0288">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label xml:lang="en">Scandinavia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
+        <rdfs:label>obsolete Scandinavia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10601,9 +7931,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0289 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0289">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
-        <rdfs:label xml:lang="en">South Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South_Asia"/>
+        <rdfs:label>obsolete South Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10669,19 +7999,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0307">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid956"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Italian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid956">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0307"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid956"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10918,19 +8243,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0321">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid976"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Finnish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid976">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0321"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid976"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11007,25 +8327,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0331">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid984"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid984">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid984"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11033,25 +8342,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0332">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid987"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sahrawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid987">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid987"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11059,25 +8357,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0333">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid990"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Anguillan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid990">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid990"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11085,25 +8372,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid993"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Antiguan or Barbudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid993">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid993"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11111,25 +8387,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0335">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid996"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Barbadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid996">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid996"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11137,25 +8402,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0336">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid999"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Haitian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid999">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid999"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11163,25 +8417,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid1002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jamaican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1002">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1002"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11189,25 +8432,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0338">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1005"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tajikistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1005">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1005"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11215,25 +8447,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1008"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkmen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1008">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11241,25 +8462,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1011"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uzbekistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1011">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11267,19 +8477,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0341">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Afghan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1013">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0341"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1013"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11287,25 +8492,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0342">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1016"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kazakhstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1016">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11313,25 +8507,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1019"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kyrgyzstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1019">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1019"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11339,19 +8522,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0344">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1021"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Albanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1021">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0344"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1021"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11359,19 +8537,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0345">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1023"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Andorran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1023">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0345"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1023"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11379,19 +8552,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0346">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1025"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Australian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1025">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0346"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1025"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11399,19 +8567,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0347">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Austrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1027">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0347"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1027"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11419,19 +8582,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0348">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1029"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belarusian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1029">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0348"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1029"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11439,19 +8597,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1031"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1031">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0349"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1031"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11459,19 +8612,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0350">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1033"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bermudian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1033">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0350"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1033"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11479,19 +8627,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0351">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1035"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bosnian or Herzegovinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1035">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0351"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1035"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11499,19 +8642,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1037"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Brazilian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1037">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0352"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1037"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11519,19 +8657,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1039"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bulgarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1039">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0353"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1039"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11539,19 +8672,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0354">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1041"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Canadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1041">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0354"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1041"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11559,19 +8687,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0355">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1043"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Channel Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1043">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0355"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1043"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11579,19 +8702,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0356">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1045"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chilean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1045">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0356"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1045"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11599,19 +8717,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0357">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1047"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Croatian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1047">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0357"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1047"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11619,19 +8732,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0358">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1049"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Czech</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1049">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0358"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1049"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11639,19 +8747,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0359">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1051"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Danish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1051">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0359"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1051"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11659,19 +8762,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0360">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1053"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Estonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1053">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0360"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1053"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11679,19 +8777,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0361">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1055"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Faroese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1055">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0361"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1055"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11699,19 +8792,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0362">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1057"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Falkland Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1057">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0362"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1057"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11719,19 +8807,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0363">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1059"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1059">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0363"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1059"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11739,19 +8822,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0364">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1061"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">German</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1061">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0364"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1061"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11759,19 +8837,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0365">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1063"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gibraltarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1063">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0365"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1063"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11779,19 +8852,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1065"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greek</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1065">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0366"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1065"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11799,19 +8867,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0367">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1067"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greenlander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1067">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0367"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1067"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11819,19 +8882,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0368">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1069"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Hungarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1069">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0368"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1069"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11839,19 +8897,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0369">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1071"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Icelandic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1071">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0369"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1071"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11859,19 +8912,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0370">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1073"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Manx</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1073">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0370"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1073"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11879,19 +8927,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0371">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1075"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Latvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1075">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0371"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1075"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11899,19 +8942,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0372">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1077"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liechtensteiner</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1077">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0372"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1077"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11919,19 +8957,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0373">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1079"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lithuanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1079">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0373"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1079"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11939,19 +8972,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1081"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Luxembourgish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1081">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0374"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1081"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11959,19 +8987,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0375">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1083"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maltese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1083">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0375"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1083"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11979,19 +9002,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0376">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1085"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Monegasque</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1085">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0376"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1085"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11999,19 +9017,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0377">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1087"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montenegrin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1087">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0377"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1087"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12019,19 +9032,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0378">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1089"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Zealandish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1089">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0378"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1089"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12040,7 +9048,12 @@ from this region. This category includes individuals with known admixture of pri
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0379">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0290"/>
-        <rdfs:subClassOf rdf:nodeID="genid1092"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0301"/>
@@ -12053,8 +9066,8 @@ from this region. This category includes individuals with known admixture of pri
                 <owl:allValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Polynesia"/>
                             <rdf:Description rdf:about="http://dbpedia.org/resource/United_Kingdom"/>
-                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
                         </owl:intersectionOf>
                     </owl:Class>
                 </owl:allValuesFrom>
@@ -12062,22 +9075,6 @@ from this region. This category includes individuals with known admixture of pri
         </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norfolk Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1092">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1092"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12085,19 +9082,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0380">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1099"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norwegian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1099">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0380"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1099"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12105,19 +9097,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0381">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1101"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Polish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1101">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0381"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1101"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12125,19 +9112,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0382">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1103"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Portugese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1103">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0382"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1103"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12145,19 +9127,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0383">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1105"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Irish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1105">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0383"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1105"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12165,19 +9142,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0384">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1107"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moldovan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1107">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0384"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1107"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12185,19 +9157,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0385">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1109"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Romanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1109">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0385"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1109"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12205,25 +9172,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1112"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Russian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1112">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1112"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12231,19 +9187,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0387">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1114"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint-Pierrais or Miquelonnais</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1114">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0387"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1114"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12251,19 +9202,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0388">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1116"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sammarinese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1116">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0388"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1116"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12271,19 +9217,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0389">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1118"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Serb</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1118">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0389"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1118"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12291,19 +9232,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0390">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1120"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovak</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1120">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0390"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1120"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12311,19 +9247,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0391">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1122"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovene</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1122">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0391"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1122"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12331,19 +9262,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0392">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1124"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Spanish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1124">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0392"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1124"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12351,19 +9277,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0393">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1126"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swedish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1126">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0393"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1126"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12371,19 +9292,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0394">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1128"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swiss</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1128">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0394"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1128"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12391,19 +9307,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1130"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Macedonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1130">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0395"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1130"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12411,19 +9322,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1132"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ukrainian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1132">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0396"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1132"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12431,25 +9337,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1135"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Argentine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1135">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1135"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12457,25 +9352,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0398">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1138"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahamian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1138">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1138"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12483,25 +9367,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1141"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belizean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1141">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1141"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12509,25 +9382,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1144"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bolivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1144">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1144"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12535,25 +9397,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0401">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1147"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1147">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1147"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12561,25 +9412,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1150"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Caymanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1150">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1150"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12587,25 +9427,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0403">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1153"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Colombian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1153">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1153"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12613,25 +9442,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0404">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1156"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Costa Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1156">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1156"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12639,25 +9457,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0405">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1159"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cuban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1159">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1159"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12665,25 +9472,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0406">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1162"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Dominican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1162">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1162"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12691,25 +9487,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0407">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1165"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ecuadorian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1165">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1165"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12717,25 +9502,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0408">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1168"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Salvadoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1168">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1168"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12743,25 +9517,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0409">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1171"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Guianese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1171">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1171"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12769,25 +9532,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0410">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1174"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Grenadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1174">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1174"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12795,25 +9547,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0411">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1177"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guatemalan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1177">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1177"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12821,25 +9562,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0412">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1180"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guyanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1180">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1180"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12847,25 +9577,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0413">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1183"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Honduran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1183">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1183"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12873,25 +9592,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0414">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1186"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Martinican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1186">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1186"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12899,25 +9607,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0415">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1189"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mexican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1189">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1189"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12925,25 +9622,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0416">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1192"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montserratian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1192">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1192"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12951,25 +9637,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0417">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1195"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nicaraguan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1195">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1195"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12977,25 +9652,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0418">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1198"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Panamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1198">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1198"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13003,25 +9667,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0419">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1201"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Paraguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1201">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1201"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13029,25 +9682,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1204"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Peruvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1204">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1204"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13055,25 +9697,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0421">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1207"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Puerto Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1207">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1207"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13081,25 +9712,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1210"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kittitian or Nevisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1210">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1210"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13107,25 +9727,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0423">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1213"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Lucian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1213">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1213"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13133,25 +9742,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0424">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1216"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Vincentian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1216">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1216"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13159,26 +9757,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0425">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1219"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Surinamer</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Surinamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1219">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1219"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13186,25 +9773,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0426">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1222"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Trinidadian or Tobagonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1222">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1222"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13212,25 +9788,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0427">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1225"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turks and Caicos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1225">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1225"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13238,25 +9803,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0428">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1228"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1228">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1228"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13264,25 +9818,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0429">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1231"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uruguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1231">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1231"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13290,25 +9833,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0430">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1234"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Venezuelan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1234">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1234"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13316,25 +9848,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0431">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1237"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Algerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1237">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1237"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13342,25 +9863,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1240"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Armenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1240">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1240"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13368,25 +9878,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0433">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1243"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Azerbaijani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1243">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1243"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13394,25 +9893,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0434">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1246"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahraini</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1246">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1246"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13420,25 +9908,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0435">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1249"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cypriote</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1249">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1249"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13446,25 +9923,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0436">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1252"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Egyptian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1252">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1252"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13472,25 +9938,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0437">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1255"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Georgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1255">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1255"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13498,25 +9953,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0438">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1258"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iranian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1258">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1258"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13524,25 +9968,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0439">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1261"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iraqi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1261">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1261"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13550,25 +9983,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0440">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1264"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Israeli</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1264">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1264"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13576,25 +9998,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0441">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1267"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jordanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1267">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1267"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13602,25 +10013,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1270"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kuwaiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1270">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1270"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13628,25 +10028,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1273"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lebanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1273">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1273"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13654,25 +10043,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0444">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1276"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Libyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1276">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1276"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13680,25 +10058,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0445">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1279"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moroccan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1279">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1279"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13706,25 +10073,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0446">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1282"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palestinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1282">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1282"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13732,25 +10088,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0447">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1285"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Omani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1285">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1285"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13758,25 +10103,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0448">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1288"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Qatari</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1288">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1288"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13784,26 +10118,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0449">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1291"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Saudi Arab</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Saudi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1291">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1291"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13811,25 +10134,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0450">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1294"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tunisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1294">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1294"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13837,25 +10149,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0451">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1297"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1297">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1297"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13863,25 +10164,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0452">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1300"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Emirati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1300">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1300"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13889,25 +10179,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0453">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1303"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Yemeni</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1303">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1303"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13915,25 +10194,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0454">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1306"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Aruban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1306">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1306"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13941,25 +10209,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0455">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1309"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Christmas Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1309">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1309"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13967,25 +10224,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0456">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1312"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cocos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1312">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1312"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13993,25 +10239,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0457">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1315"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Curacaoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1315">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1315"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14019,25 +10254,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0458">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1318"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kosovar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1318">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1318"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14045,25 +10269,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0459">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1321"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Northern Mariana Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1321">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1321"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14071,25 +10284,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0460">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1324"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1324">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1324"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14097,25 +10299,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0461">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1327"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Syrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1327">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1327"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14123,19 +10314,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0462">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1329"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1329">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0462"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1329"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14143,25 +10329,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1332"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1332">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1332"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14169,25 +10344,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0464">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1335"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1335">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1335"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14195,25 +10359,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0465">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1338"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cook Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1338">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1338"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14221,25 +10374,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1341"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Fijian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1341">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1341"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14247,25 +10389,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0467">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1344"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Polynesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1344">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1344"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14273,25 +10404,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1347"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1347">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1347"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14299,25 +10419,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1350"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">I-Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1350">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1350"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14325,25 +10434,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0470">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1353"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Marshallese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1353">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1353"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14351,25 +10449,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1356"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Micronesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1356">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1356"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14377,25 +10464,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0472">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1359"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nauruan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1359">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1359"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14403,25 +10479,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0473">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1362"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Caledonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1362">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1362"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14429,25 +10494,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0474">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1365"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Niuean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1365">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1365"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14455,25 +10509,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0475">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1368"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1368">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1368"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14481,25 +10524,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1371"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Papua New Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1371">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1371"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14507,25 +10539,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0477">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1374"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pitcairn Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1374">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1374"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14533,25 +10554,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0478">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1377"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1377">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1377"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14559,25 +10569,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1380"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Solomon Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1380">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1380"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14585,25 +10584,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0480">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1383"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tokelauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1383">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1383"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14611,25 +10599,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0481">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1386"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tongan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1386">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1386"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14637,25 +10614,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0482">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1389"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tuvaluan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1389">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1389"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14663,25 +10629,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0483">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1392"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ni-Vanuato</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1392">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1392"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14689,25 +10644,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1395"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Wallis and Futuna Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1395">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1395"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14715,25 +10659,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1398"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bangladeshi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1398">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1398"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14741,25 +10674,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1401"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bhutanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1401">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1401"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14767,27 +10689,16 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0487">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1404"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Asian Indian</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Indian Asian</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Indian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1404">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1404"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14795,25 +10706,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0488">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1407"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maldivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1407">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1407"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14821,25 +10721,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0489">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1410"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nepalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1410">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1410"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14847,25 +10736,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0490">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1413"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pakistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1413">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1413"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14873,25 +10751,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0491">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1416"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sri Lankan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1416">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1416"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14899,25 +10766,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0492">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1419"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bruneian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1419">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1419"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14925,25 +10781,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0493">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1422"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cambodian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1422">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1422"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14951,25 +10796,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1425"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Indonesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1425">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1425"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14977,25 +10811,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1428"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lao</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1428">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1428"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15003,25 +10826,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0496">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1431"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malaysian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1431">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1431"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15029,25 +10841,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0497">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1434"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burmese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1434">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1434"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15055,25 +10856,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0498">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1437"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Filipino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1437">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1437"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15081,25 +10871,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1440"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Thai</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1440">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1440"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15107,25 +10886,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1443"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Timorese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1443">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1443"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15133,25 +10901,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1446"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Vietnamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1446">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1446"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15159,25 +10916,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1449"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cameroonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1449">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1449"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15185,19 +10931,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1451"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cape Verdean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1451">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0504"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1451"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15205,25 +10946,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0505">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1454"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1454">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1454"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15231,25 +10961,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0506">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1457"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ethiopian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1457">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1457"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15257,25 +10976,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1460"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kenyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1460">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1460"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15283,25 +10991,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1463"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liberian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1463">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1463"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15309,25 +11006,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0509">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1466"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malagasy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1466">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1466"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15335,25 +11021,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0510">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1469"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1469">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1469"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15361,25 +11036,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0511">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1472"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1472">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1472"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15387,25 +11051,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0512">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1475"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mahoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1475">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1475"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15413,25 +11066,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0513">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1478"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Namibian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1478">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1478"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15439,25 +11081,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1481"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sao Tomean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1481">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1481"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15465,25 +11096,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0515">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1484"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Senegalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1484">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1484"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15491,25 +11111,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0516">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1487"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Seychellois</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1487">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1487"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15517,25 +11126,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1490"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sierra Leonean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1490">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1490"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15543,25 +11141,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0518">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1493"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Somali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1493">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1493"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15569,25 +11156,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0519">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1496"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1496">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1496"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15595,25 +11171,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0520">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1499"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">St. Helenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1499">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1499"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15621,25 +11186,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0521">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1502"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ugandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1502">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1502"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15647,25 +11201,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0522">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1505"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Angolan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1505">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1505"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15673,25 +11216,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0523">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1508"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Beninese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1508">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1508"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15699,25 +11231,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0524">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1511"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Motswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1511">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1511"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15725,25 +11246,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0525">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1514"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burkinabe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1514">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1514"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15751,25 +11261,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0526">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1517"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burundian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1517">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1517"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15777,25 +11276,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0527">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1520"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Central African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1520">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1520"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15803,25 +11291,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0528">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1523"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Comoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1523">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1523"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15829,36 +11306,20 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0529">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1526"/>
-        <rdfs:subClassOf rdf:nodeID="genid1528"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Congolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1526">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Restriction rdf:nodeID="genid1528">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1526"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1528"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15866,25 +11327,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1531"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ivoirian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1531">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1531"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15892,25 +11342,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0531">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1534"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Djiboutian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1534">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1534"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15918,25 +11357,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0532">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1537"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Equatorial Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1537">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1537"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15944,25 +11372,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0533">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1540"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Eritrean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1540">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1540"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15970,25 +11387,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0534">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1543"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gabonese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1543">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1543"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15996,25 +11402,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0535">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1546"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1546">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1546"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16022,25 +11417,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0536">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1549"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ghanaian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1549">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1549"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16048,25 +11432,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0537">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1552"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1552">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1552"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16074,25 +11447,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0538">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1555"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bissau-Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1555">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1555"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16100,25 +11462,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0539">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1558"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mosotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1558">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1558"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16126,25 +11477,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0540">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1561"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malawian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1561">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1561"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16152,25 +11492,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0541">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1564"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1564">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1564"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16178,25 +11507,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0542">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1567"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mozambican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1567">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1567"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16204,25 +11522,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0543">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1570"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerien</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1570">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1570"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16230,25 +11537,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0544">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1573"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1573">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1573"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16256,25 +11552,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0545">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1576"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Rwandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1576">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1576"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16282,25 +11567,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0546">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1579"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swazi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1579">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1579"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16308,19 +11582,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0547">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1581"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Togolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1581">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0547"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1581"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16328,19 +11597,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0548">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1583"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tanzanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1583">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0548"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1583"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16348,19 +11612,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0549">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1585"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1585">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0549"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1585"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16368,25 +11627,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0550">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1588"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zimbabweian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1588">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1588"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16988,6 +12236,22 @@ category does not include all native populations within the Arctic circle for ex
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCIT_C25464 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C25464">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115>A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states.</obo:IAO_0000115>
+        <rdfs:label>Country</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/OBI_0000181 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000181">
@@ -17117,45 +12381,39 @@ for now.</obo:IAO_0000116>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000020"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Oceania"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Central_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Melanesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Micronesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Middle_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Polynesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Scandinavia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-central_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/SouthAmerica"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Europe"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
         </owl:members>
     </rdf:Description>
     

--- a/hancestro.json
+++ b/hancestro.json
@@ -19,9 +19,9 @@
         "val" : "http://creativecommons.org/licenses/by/4.0/"
       }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2023-10-13"
+        "val" : "2024-01-24"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro.json"
+      "version" : "http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro.json"
     },
     "nodes" : [ {
       "id" : "http://dbpedia.org/resource/Afghanistan",
@@ -30,6 +30,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00006882"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Africa",
+      "lbl" : "Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000457"
         } ]
       }
     }, {
@@ -120,6 +129,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00004025"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Asia",
+      "lbl" : "Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000465"
         } ]
       }
     }, {
@@ -352,6 +370,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Caribbean",
+      "lbl" : "Caribbean",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Cayman_Islands",
       "lbl" : "Cayman Islands",
       "type" : "CLASS",
@@ -367,6 +389,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00001089"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Central_America",
+      "lbl" : "Central America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002891"
         } ]
       }
     }, {
@@ -554,6 +585,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Africa",
+      "lbl" : "Eastern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000556"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Asia",
+      "lbl" : "Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002471"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Eastern_Europe",
+      "lbl" : "Eastern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Ecuador",
       "lbl" : "Ecuador",
       "type" : "CLASS",
@@ -614,6 +667,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000567"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Europe",
+      "lbl" : "Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000464"
         } ]
       }
     }, {
@@ -1046,6 +1108,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "lbl" : "Latin America and the Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Latvia",
       "lbl" : "Latvia",
       "type" : "CLASS",
@@ -1238,6 +1309,15 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Melanesia",
+      "lbl" : "Melanesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005860"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/Mexico",
       "lbl" : "Mexico",
       "type" : "CLASS",
@@ -1246,6 +1326,19 @@
           "val" : "GAZ:00002852"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Micronesia",
+      "lbl" : "Micronesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005862"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Middle_Africa",
+      "lbl" : "Middle Africa",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Moldova",
       "lbl" : "Moldova",
@@ -1452,6 +1545,28 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Northern_Africa",
+      "lbl" : "Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000555"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_America",
+      "lbl" : "Northern America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000458"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Northern_Europe",
+      "lbl" : "Northern Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "lbl" : "Northern Mariana Islands",
       "type" : "CLASS",
@@ -1471,6 +1586,15 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
           "val" : "Kingdom of Norway"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Oceania",
+      "lbl" : "Oceania",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000468"
         } ]
       }
     }, {
@@ -1586,6 +1710,15 @@
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00002939"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Polynesia",
+      "lbl" : "Polynesia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00005861"
         } ]
       }
     }, {
@@ -1792,6 +1925,10 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Scandinavia",
+      "lbl" : "Scandinavia",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Scotland",
       "lbl" : "Scotland",
       "type" : "CLASS",
@@ -1891,12 +2028,43 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "lbl" : "South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000559"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South-central_Asia",
+      "lbl" : "South-Central Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/SouthAmerica",
+      "lbl" : "South America",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000459"
+        } ]
+      }
+    }, {
       "id" : "http://dbpedia.org/resource/South_Africa",
       "lbl" : "South Africa",
       "type" : "CLASS",
       "meta" : {
         "xrefs" : [ {
           "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/South_Asia",
+      "lbl" : "South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00002472"
         } ]
       }
     }, {
@@ -1921,6 +2089,19 @@
           "val" : "GAZ:00233439"
         } ]
       }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Africa",
+      "lbl" : "Southern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000553"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Southern_Europe",
+      "lbl" : "Southern Europe",
+      "type" : "CLASS"
     }, {
       "id" : "http://dbpedia.org/resource/Spain",
       "lbl" : "Spain",
@@ -2278,6 +2459,23 @@
         } ]
       }
     }, {
+      "id" : "http://dbpedia.org/resource/Western_Africa",
+      "lbl" : "Western Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "GAZ:00000554"
+        } ]
+      }
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Asia",
+      "lbl" : "Western Asia",
+      "type" : "CLASS"
+    }, {
+      "id" : "http://dbpedia.org/resource/Western_Europe",
+      "lbl" : "Western Europe",
+      "type" : "CLASS"
+    }, {
       "id" : "http://dbpedia.org/resource/Western_Sahara",
       "lbl" : "Western Sahara",
       "type" : "CLASS",
@@ -2424,44 +2622,7 @@
       "meta" : {
         "definition" : {
           "val" : "An entity that has temporal parts and that happens, unfolds or develops through time."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "occurrent"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Occurrent"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000004",
@@ -2531,37 +2692,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000006",
       "lbl" : "spatial region",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "s-region"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "SpatialRegion"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Spatial regions do not participate in processes."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000015",
       "lbl" : "process",
@@ -2575,46 +2706,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000016",
       "lbl" : "disposition",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "disposition"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Disposition"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "an atom of element X has the disposition to decay to an atom of element Y"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "certain people have a predisposition to colon cancer"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "children are innately disposed to categorize objects in certain ways."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000017",
       "lbl" : "realizable entity",
@@ -2622,44 +2714,7 @@
       "meta" : {
         "definition" : {
           "val" : "A specifically dependent continuant  that inheres in continuant  entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "realizable"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "RealizableEntity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the disposition of this piece of metal to conduct electricity."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the disposition of your blood to coagulate"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of your reproductive organs"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of being a doctor"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of this boundary to delineate where Utah and Colorado meet"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000601",
-          "val" : "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000019",
@@ -2760,9 +2815,6 @@
           "val" : "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] "
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
           "val" : "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] "
         }, {
           "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
@@ -2776,114 +2828,12 @@
       "meta" : {
         "definition" : {
           "val" : "A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the priest role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a boundary to demarcate two neighboring administrative territories"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a building in serving as a military target"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of a stone in marking a property boundary"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the role of subject in a clinical trial"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the student role"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/BFO_0000031",
-      "lbl" : "generically dependent continuant",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"
-        },
-        "comments" : [ "A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time." ],
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "gdc"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "GenericallyDependentContinuant"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000034",
       "lbl" : "function",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "function"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "Function"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of a hammer to drive in nails"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of a heart pacemaker to regulate the beating of a heart through electricity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
-          "val" : "the function of amylase in saliva to break down starch into sugar"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000600",
-          "val" : "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000602",
-          "val" : "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] "
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
+      "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000040",
       "lbl" : "material entity",
@@ -3118,73 +3068,13 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/BFO_0000141",
       "lbl" : "immaterial entity",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000179",
-          "val" : "immaterial"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/BFO_0000180",
-          "val" : "ImmaterialEntity"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
-          "val" : "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/bfo.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000334",
-      "lbl" : "subcontinental land mass",
       "type" : "CLASS"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000370",
-      "lbl" : "geographical entity",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface)."
-        },
-        "comments" : [ "Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.\n\nGenerally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.", "Note that despite the word 'planetary' in 'planetary surface', it refers generally to surface of dwarf planets, asteroids, moons, etc.", "We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.", "We note that the term 'geography' is also applied to the Earth's moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  \n\nThus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc." ],
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
-          "val" : "geographical entity of astronomical body"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Mathias Brochhausen"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Matt Diller"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "William R. Hogan"
-        } ]
-      }
+      "id" : "http://purl.obolibrary.org/obo/COB_0000032",
+      "lbl" : "geographical location",
+      "type" : "CLASS"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000372",
-      "lbl" : "geographical region",
-      "type" : "CLASS",
-      "meta" : {
-        "definition" : {
-          "val" : "A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface."
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "François Modave"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Mathias Brochhausen"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Matt Diller"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "William R. Hogan"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000374",
+      "id" : "http://purl.obolibrary.org/obo/GAZ_00000013",
       "lbl" : "continent",
       "type" : "CLASS",
       "meta" : {
@@ -3194,26 +3084,6 @@
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "major area"
-        } ],
-        "xrefs" : [ {
-          "val" : "GAZ:00190836"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000375",
-      "lbl" : "land mass",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/GEO_000000391",
-      "lbl" : "geopolitical organization",
-      "type" : "CLASS",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
-          "val" : "geopolitical organization"
-        }, {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "Amanda Hicks"
         } ]
       }
     }, {
@@ -3231,7 +3101,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "lbl" : "country",
+      "lbl" : "obsolete country",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -3240,7 +3110,11 @@
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "NCIT:C25464"
-        } ]
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
@@ -3446,152 +3320,234 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "lbl" : "Africa",
+      "lbl" : "obsolete Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000457"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "lbl" : "Asia",
+      "lbl" : "obsolete Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000465"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "lbl" : "Europe",
+      "lbl" : "obsolete Europe",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000464"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Europe"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "lbl" : "Oceania",
+      "lbl" : "obsolete Oceania",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000468"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Oceania"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "lbl" : "Latin America and the Caribbean",
+      "lbl" : "obsolete Latin America and the Caribbean",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "lbl" : "Northern America",
+      "lbl" : "obsolete Northern America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000458"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "lbl" : "Eastern Africa",
+      "lbl" : "obsolete Eastern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000556"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "lbl" : "Middle Africa",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "lbl" : "Northern Africa",
+      "lbl" : "obsolete Middle Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000555"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Middle_Africa"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
+      "lbl" : "obsolete Northern Africa",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "lbl" : "Southern Africa",
+      "lbl" : "obsolete Southern Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000553"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "lbl" : "Western Africa",
+      "lbl" : "obsolete Western Africa",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000554"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Africa"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "lbl" : "South-Central Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "lbl" : "South-Eastern Asia",
+      "lbl" : "obsolete South Central Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000559"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-central_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
+      "lbl" : "obsolete South-Eastern Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South-Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "lbl" : "Western Asia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "lbl" : "Eastern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "lbl" : "Northern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "lbl" : "Southern Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "lbl" : "Western Europe",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "lbl" : "Caribbean",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "lbl" : "South America",
+      "lbl" : "obsolete Western Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00000459"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Asia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
+      "lbl" : "obsolete Eastern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
+      "lbl" : "obsolete Northern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Northern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
+      "lbl" : "obsolete Southern Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Southern_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
+      "lbl" : "obsolete Western Europe",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Western_Europe"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
+      "lbl" : "obsolete Caribbean",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Caribbean"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
+      "lbl" : "obsolete South America",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/SouthAmerica"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "lbl" : "Central America",
+      "lbl" : "obsolete Central America",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002891"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Central_America"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
@@ -3599,39 +3555,47 @@
       "type" : "CLASS"
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "lbl" : "Melanesia",
+      "lbl" : "obsolete Melanesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005860"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Melanesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "lbl" : "Micronesia",
+      "lbl" : "obsolete Micronesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005862"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Micronesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "lbl" : "Polynesia",
+      "lbl" : "obsolete Polynesia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00005861"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Polynesia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-      "lbl" : "Eastern Asia",
+      "lbl" : "obsolete Eastern Asia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002471"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Eastern_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0286",
@@ -3651,16 +3615,25 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "lbl" : "Scandinavia",
-      "type" : "CLASS"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "lbl" : "South Asia",
+      "lbl" : "obsolete Scandinavia",
       "type" : "CLASS",
       "meta" : {
-        "xrefs" : [ {
-          "val" : "GAZ:00002472"
-        } ]
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/Scandinavia"
+        } ],
+        "deprecated" : true
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
+      "lbl" : "obsolete South Asia",
+      "type" : "CLASS",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://dbpedia.org/resource/South_Asia"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
@@ -5040,9 +5013,6 @@
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
-        }, {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -5067,23 +5037,7 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
       "lbl" : "definition",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/IAO_0000116",
-      "lbl" : "editor note",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000117",
       "lbl" : "term editor",
@@ -5097,23 +5051,11 @@
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000118",
       "lbl" : "alternative_term",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000119",
       "lbl" : "definition_source",
-      "type" : "PROPERTY",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
-          "val" : "http://purl.obolibrary.org/obo/iao.owl"
-        } ]
-      }
+      "type" : "PROPERTY"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000700",
       "lbl" : "has ontology root term",
@@ -5134,6 +5076,15 @@
       "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
       "lbl" : "term replaced by",
       "type" : "PROPERTY"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/NCIT_C25464",
+      "lbl" : "Country",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states."
+        }
+      }
     }, {
       "id" : "http://purl.obolibrary.org/obo/OBI_0000181",
       "lbl" : "population",
@@ -7247,2331 +7198,1073 @@
     "edges" : [ {
       "sub" : "http://dbpedia.org/resource/Afghanistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Albania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Algeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/American_Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Andorra",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Angola",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Anguilla",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Argentina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Armenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Aruba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Australia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Austria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Azerbaijan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bahrain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bangladesh",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Barbados",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belarus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belgium",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Belize",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Benin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bermuda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bhutan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bolivia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Botswana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brazil",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Brunei",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Bulgaria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burkina_Faso",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Burundi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cambodia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cameroon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Canada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cape_Verde",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Cayman_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Central_African_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Central_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Chad",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Channel_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Chile",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/China",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Christmas_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Colombia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Comoros",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cook_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Costa_Rica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Croatia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cuba",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Curacao",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cyprus",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Czech_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Denmark",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Djibouti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Dominican_Republic",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/East_Timor",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Ecuador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Egypt",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/El_Salvador",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Eritrea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Estonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ethiopia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Falkland_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Fiji",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Finland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/France",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Guiana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/French_Polynesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gabon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Germany",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ghana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Gibraltar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greece",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Greenland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Grenada",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guadeloupe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guatemala",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Guyana",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Haiti",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Holy_See",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Honduras",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hong_Kong",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Hungary",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iceland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/India",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Indonesia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iran",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Iraq",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Isle_of_Man",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Israel",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Italy",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ivory_Coast",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jamaica",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Japan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Jordan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kazakhstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kenya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kiribati",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kosovo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kuwait",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Laos",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Latvia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lebanon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lesotho",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liberia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Libya",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Liechtenstein",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Lithuania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Luxembourg",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Macau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Madagascar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malawi",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malaysia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Maldives",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mali",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Malta",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Marshall_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Martinique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauretania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mauritius",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mayotte",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Melanesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Mexico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Micronesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Middle_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Moldova",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Monaco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mongolia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montenegro",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Montserrat",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Morocco",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Mozambique",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Myanmar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Namibia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nauru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nepal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Caledonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/New_Zealand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nicaragua",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niger",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Nigeria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Niue",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norfolk_Island",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/North_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_America",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Northern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Norway",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Oceania",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
     }, {
       "sub" : "http://dbpedia.org/resource/Oman",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pakistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Palestinian_territories",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Panama",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Paraguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Peru",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Philippines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Poland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Polynesia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Portugal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Puerto_Rico",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Qatar",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Romania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Russia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Rwanda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Réunion",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Helena",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Lucia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Martin",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Samoa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/San_Marino",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Scandinavia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Scotland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Senegal",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Serbia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Seychelles",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sierra_Leone",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Singapore",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sint_Maarten",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovakia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Slovenia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Solomon_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Somalia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South-central_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/SouthAmerica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Africa",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/South_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Korea",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/South_Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Southern_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Spain",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sri_Lanka",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sudan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Suriname",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Swaziland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Sweden",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Switzerland",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Syria",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Taiwan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tajikistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tanzania",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Thailand",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Bahamas",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/The_Gambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Togo",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tokelau",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tonga",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tunisia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkey",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turkmenistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Tuvalu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uganda",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Ukraine",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_Kingdom",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uruguay",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Uzbekistan",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vanuatu",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Venezuela",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Vietnam",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Africa",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Asia",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
+    }, {
+      "sub" : "http://dbpedia.org/resource/Western_Europe",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://dbpedia.org/resource/Western_Sahara",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Yemen",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zambia",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Zimbabwe",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003"
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://dbpedia.org/resource/Georgia_(country)",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/NCIT_C25464"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/BFO_0000002",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000001"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/BFO_0000003",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000001"
     }, {
@@ -9607,10 +8300,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000017"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/BFO_0000031",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/BFO_0000034",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000016"
@@ -9623,41 +8312,17 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/BFO_0000004"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000334",
+      "sub" : "http://purl.obolibrary.org/obo/COB_0000032",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000375"
+      "obj" : "http://purl.obolibrary.org/obo/BFO_0000141"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000334",
-      "pred" : "http://purl.obolibrary.org/obo/BFO_0000137",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000370",
+      "sub" : "http://purl.obolibrary.org/obo/GAZ_00000013",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/BFO_0000040"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000372",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000370"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000374",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000375"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000375",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000372"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/GEO_000000391",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/OBI_0000245"
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000334"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000391"
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0004",
       "pred" : "is_a",
@@ -9791,121 +8456,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0021"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0034",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/GEO_000000374"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0286",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0289",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0290",
       "pred" : "is_a",
@@ -9929,13 +8486,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0307",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Italy",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Italy"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0309",
       "pred" : "is_a",
@@ -10035,13 +8586,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0321",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Finland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Finland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0322",
       "pred" : "is_a",
@@ -10069,203 +8614,83 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0331",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0332",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Western_Sahara",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Western_Sahara"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0333",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Anguilla",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Anguilla"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0334",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Antigua_and_Barbuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0335",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Barbados",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Barbados"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0336",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Haiti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Haiti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0016"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0337",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jamaica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jamaica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0338",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tajikistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tajikistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0339",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkmenistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkmenistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0340",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uzbekistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uzbekistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "is_a",
@@ -10273,53 +8698,23 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0341",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Afghanistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Afghanistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0342",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kazakhstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kazakhstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0343",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kyrgyzstan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kyrgyzstan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "is_a",
@@ -10327,13 +8722,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0344",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Albania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Albania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "is_a",
@@ -10341,13 +8730,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0345",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Andorra",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Andorra"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "is_a",
@@ -10355,13 +8738,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0346",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Australia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Australia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "is_a",
@@ -10369,13 +8746,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0347",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Austria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Austria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "is_a",
@@ -10383,13 +8754,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0348",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belarus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belarus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "is_a",
@@ -10397,13 +8762,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0349",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belgium",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belgium"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "is_a",
@@ -10411,13 +8770,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0350",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bermuda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bermuda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "is_a",
@@ -10425,13 +8778,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0351",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "is_a",
@@ -10439,13 +8786,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0352",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brazil",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brazil"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "is_a",
@@ -10453,13 +8794,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0353",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bulgaria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bulgaria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "is_a",
@@ -10467,13 +8802,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0354",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Canada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Canada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "is_a",
@@ -10481,13 +8810,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0355",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Channel_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Channel_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "is_a",
@@ -10495,13 +8818,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0356",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chile",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chile"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "is_a",
@@ -10509,13 +8826,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0357",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Croatia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Croatia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "is_a",
@@ -10523,13 +8834,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0358",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Czech_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Czech_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "is_a",
@@ -10537,13 +8842,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0359",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Denmark",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Denmark"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "is_a",
@@ -10551,13 +8850,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0360",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Estonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Estonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "is_a",
@@ -10565,13 +8858,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0361",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Faeroe_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Faeroe_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "is_a",
@@ -10579,13 +8866,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0362",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Falkland_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Falkland_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "is_a",
@@ -10593,13 +8874,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0363",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/France",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/France"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "is_a",
@@ -10607,13 +8882,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0364",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Germany",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Germany"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "is_a",
@@ -10621,13 +8890,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0365",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gibraltar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gibraltar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "is_a",
@@ -10635,13 +8898,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0366",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greece",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greece"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "is_a",
@@ -10649,13 +8906,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0367",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Greenland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Greenland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "is_a",
@@ -10663,13 +8914,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0368",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Hungary",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Hungary"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "is_a",
@@ -10677,13 +8922,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0369",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iceland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iceland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "is_a",
@@ -10691,13 +8930,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0370",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Isle_of_Man",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Isle_of_Man"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "is_a",
@@ -10705,13 +8938,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0371",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Latvia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Latvia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "is_a",
@@ -10719,13 +8946,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0372",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liechtenstein",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liechtenstein"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "is_a",
@@ -10733,13 +8954,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0373",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lithuania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lithuania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "is_a",
@@ -10747,13 +8962,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0374",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Luxembourg",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Luxembourg"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "is_a",
@@ -10761,13 +8970,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0375",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malta",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malta"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "is_a",
@@ -10775,13 +8978,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0376",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Monaco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Monaco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "is_a",
@@ -10789,13 +8986,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0377",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montenegro",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montenegro"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "is_a",
@@ -10803,23 +8994,11 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0378",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Zealand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Zealand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "is_a",
@@ -10827,13 +9006,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0379",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norfolk_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norfolk_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "is_a",
@@ -10841,13 +9014,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0380",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Norway",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Norway"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "is_a",
@@ -10855,13 +9022,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0381",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Poland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Poland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "is_a",
@@ -10869,13 +9030,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0382",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Portugal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Portugal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "is_a",
@@ -10883,13 +9038,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0383",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Ireland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "is_a",
@@ -10897,13 +9046,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0384",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Moldova",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Moldova"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "is_a",
@@ -10911,33 +9054,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0385",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Romania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Romania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0386",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Russia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Russia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "is_a",
@@ -10945,13 +9070,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0387",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "is_a",
@@ -10959,13 +9078,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0388",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/San_Marino",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/San_Marino"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "is_a",
@@ -10973,13 +9086,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0389",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Serbia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Serbia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "is_a",
@@ -10987,13 +9094,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0390",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovakia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovakia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "is_a",
@@ -11001,13 +9102,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0391",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Slovenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Slovenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "is_a",
@@ -11015,13 +9110,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0392",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Spain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Spain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "is_a",
@@ -11029,13 +9118,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0393",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sweden",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sweden"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "is_a",
@@ -11043,13 +9126,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0394",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Switzerland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Switzerland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "is_a",
@@ -11057,13 +9134,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0395",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_Macedonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "is_a",
@@ -11071,1313 +9142,527 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0396",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ukraine",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ukraine"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0397",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Argentina",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Argentina"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0398",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Bahamas",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Bahamas"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0399",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Belize",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Belize"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0400",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bolivia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bolivia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0401",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/British_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0402",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cayman_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cayman_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0403",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Colombia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Colombia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0404",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Costa_Rica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Costa_Rica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0405",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cuba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cuba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0406",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Dominica",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Dominica"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0407",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ecuador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ecuador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0408",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/El_Salvador",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/El_Salvador"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0409",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Guiana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Guiana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0410",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Grenada",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Grenada"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0411",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guatemala",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guatemala"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0412",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guyana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guyana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0413",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Honduras",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Honduras"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0414",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Martinique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Martinique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0415",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mexico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mexico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0416",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Montserrat",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Montserrat"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0417",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nicaragua",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nicaragua"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0418",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Panama",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Panama"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0419",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Paraguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Paraguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0420",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Peru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Peru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0014"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0421",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Puerto_Rico",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Puerto_Rico"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0422",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0423",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Lucia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Lucia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0424",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0425",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Suriname",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Suriname"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0426",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Trinidad_and_Tobago"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0427",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0428",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States_Virgin_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0429",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uruguay",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uruguay"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0430",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Venezuela",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Venezuela"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0431",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Algeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Algeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0432",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Armenia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Armenia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0433",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Azerbaijan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Azerbaijan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0434",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bahrain",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bahrain"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0435",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cyprus",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cyprus"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0436",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Egypt",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Egypt"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0437",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Georgia_(country)",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Georgia_(country)"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0438",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iran",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iran"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0439",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Iraq",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Iraq"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0440",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Israel",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Israel"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0441",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Jordan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Jordan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0442",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kuwait",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kuwait"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0443",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lebanon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lebanon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0444",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Libya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Libya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0445",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Morocco",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Morocco"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0446",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palestinian_territories",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palestinian_territories"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0447",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Oman",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Oman"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0448",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Qatar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Qatar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0449",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saudi_Arabia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saudi_Arabia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0450",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tunisia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tunisia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0018"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0451",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Turkey",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Turkey"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0452",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Arab_Emirates"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0453",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Yemen",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Yemen"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0454",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Aruba",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Aruba"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0455",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Christmas_Island",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Christmas_Island"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0456",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0457",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Curacao",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Curacao"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0458",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kosovo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kosovo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0459",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Northern_Mariana_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0460",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Sudan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Sudan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0015"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0461",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Syria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Syria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "is_a",
@@ -12385,813 +9670,327 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0462",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_Kingdom",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_Kingdom"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0463",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/United_States",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/United_States"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0464",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/American_Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/American_Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0465",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cook_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cook_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0466",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Fiji",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Fiji"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0467",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/French_Polynesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/French_Polynesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0468",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0469",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kiribati",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kiribati"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0470",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Marshall_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Marshall_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0471",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Federated_States_of_Micronesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0472",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nauru",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nauru"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0473",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/New_Caledonia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/New_Caledonia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0474",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niue",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niue"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0475",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Palau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Palau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0476",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Papua_New_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0477",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pitcairn_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0478",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Samoa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Samoa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0017"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0479",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Solomon_Islands",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Solomon_Islands"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0480",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tokelau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tokelau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0481",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tonga",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tonga"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0482",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tuvalu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tuvalu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0483",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vanuatu",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vanuatu"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0484",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Wallis_and_Futuna"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0485",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bangladesh",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bangladesh"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0486",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Bhutan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Bhutan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0487",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/India",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/India"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0488",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Maldives",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Maldives"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0489",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nepal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nepal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0490",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Pakistan",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Pakistan"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0006"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0491",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sri_Lanka",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sri_Lanka"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0492",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Brunei",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Brunei"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0493",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cambodia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cambodia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0494",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Indonesia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Indonesia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0495",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Laos",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Laos"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0496",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malaysia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malaysia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0497",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Myanmar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Myanmar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0008"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0498",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Philippines",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Philippines"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0500",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Thailand",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Thailand"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0501",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/East_Timor",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/East_Timor"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0007"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0502",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Vietnam",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Vietnam"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0503",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cameroon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cameroon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "is_a",
@@ -13199,863 +9998,347 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0504",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Cape_Verde",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Cape_Verde"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0505",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Chad",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Chad"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0506",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ethiopia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ethiopia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0507",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Kenya",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Kenya"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0508",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Liberia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Liberia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0509",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Madagascar",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Madagascar"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0510",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauretania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauretania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0511",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mauritius",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mauritius"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0512",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mayotte",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mayotte"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0513",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Namibia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Namibia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0514",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0515",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Senegal",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Senegal"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0516",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Seychelles",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Seychelles"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0517",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Sierra_Leone",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Sierra_Leone"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0518",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Somalia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Somalia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0519",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/South_Africa",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/South_Africa"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0520",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Saint_Helena",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Saint_Helena"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0521",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Uganda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Uganda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0522",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Angola",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Angola"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0523",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Benin",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Benin"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0524",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Botswana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Botswana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0525",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burkina_Faso",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burkina_Faso"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0526",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Burundi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Burundi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0527",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Central_African_Republic",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Central_African_Republic"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0528",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Comoros",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Comoros"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0529",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Republic_of_the_Congo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0530",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ivory_Coast",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ivory_Coast"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0531",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Djibouti",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Djibouti"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0532",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Equatorial_Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0533",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Eritrea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Eritrea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0534",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Gabon",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Gabon"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0535",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/The_Gambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/The_Gambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0536",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Ghana",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Ghana"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0537",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0538",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Guinea_Bissau",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Guinea_Bissau"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0539",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Lesotho",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Lesotho"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0540",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Malawi",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Malawi"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0541",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mali",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mali"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0542",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Mozambique",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Mozambique"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0543",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Niger",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Niger"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0011"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0544",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Nigeria",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Nigeria"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0545",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Rwanda",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Rwanda"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0546",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Swaziland",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Swaziland"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "is_a",
@@ -14063,13 +10346,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0547",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Togo",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Togo"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "is_a",
@@ -14077,13 +10354,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0548",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Tanzania",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Tanzania"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "is_a",
@@ -14091,33 +10362,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0549",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zambia",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zambia"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0566"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0550",
       "pred" : "http://purl.obolibrary.org/obo/HANCESTRO_0330",
-      "obj" : "http://dbpedia.org/resource/Zimbabwe",
-      "meta" : {
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/contributor",
-          "val" : "http://e-lico.eu/populous#OPPL_pattern"
-        } ]
-      }
+      "obj" : "http://dbpedia.org/resource/Zimbabwe"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0551",
       "pred" : "is_a",
@@ -14370,6 +10623,10 @@
       "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0598",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0487"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/NCIT_C25464",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/COB_0000032"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/OBI_0000181",
       "pred" : "is_a",
@@ -14970,397 +11227,163 @@
       "allValuesFromEdges" : [ {
         "sub" : "http://dbpedia.org/resource/Afghanistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Albania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Algeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/American_Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Andorra",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Angola",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Anguilla",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Antigua_and_Barbuda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Argentina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Armenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Aruba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Australia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Austria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Azerbaijan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bahrain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bangladesh",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Barbados",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Belarus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belgium",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Belize",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Benin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Bhutan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bolivia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Bosnia_and_Herzegovina",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Botswana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Brazil",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/British_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Brunei",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Bulgaria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Burkina_Faso",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Burundi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cambodia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Cameroon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cape_Verde",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cayman_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Central_African_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Chad",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Channel_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Chile",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/China",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Christmas_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -15368,1853 +11391,767 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Colombia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Comoros",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cook_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Costa_Rica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Croatia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Cuba",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Curacao",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Cyprus",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Czech_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Democratic_Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Djibouti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Dominican_Republic",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/East_Timor",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Ecuador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Egypt",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/El_Salvador",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Equatorial_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Eritrea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Estonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ethiopia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Faeroe_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Falkland_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Federated_States_of_Micronesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Fiji",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Finland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/France",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Guiana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/French_Polynesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Gabon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Germany",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ghana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Gibraltar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Greece",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Grenada",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guadeloupe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Guam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Guatemala",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guinea_Bissau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Guyana",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Haiti",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Holy_See",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Honduras",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Hong_Kong",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Hungary",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Iceland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/India",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Indonesia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iran",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Iraq",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Isle_of_Man",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Israel",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Italy",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Ivory_Coast",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Jamaica",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Japan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Jordan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kazakhstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kenya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Kiribati",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kosovo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044"
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Kuwait",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Kyrgyzstan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Laos",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Latvia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lebanon",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Lesotho",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liberia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Libya",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Liechtenstein",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Lithuania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Luxembourg",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Macau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Madagascar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malawi",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malaysia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Maldives",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Mali",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Malta",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Marshall_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Martinique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauretania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mauritius",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mayotte",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mexico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Moldova",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Monaco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Mongolia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Montenegro",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Montserrat",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Morocco",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Mozambique",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Myanmar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Namibia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nauru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Nepal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Netherlands_Antilles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Caledonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/New_Zealand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/Nicaragua",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Niger",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Nigeria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Niue",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norfolk_Island",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0051"
       }, {
         "sub" : "http://dbpedia.org/resource/North_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Northern_Mariana_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053"
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Oman",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pakistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Micronesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Palestinian_territories",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Panama",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Central_America"
       }, {
         "sub" : "http://dbpedia.org/resource/Papua_New_Guinea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Paraguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Peru",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Philippines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Pitcairn_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Poland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Portugal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Puerto_Rico",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Qatar",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Ireland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_Macedonia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Republic_of_the_Congo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Romania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Rwanda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Réunion",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Helena",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Kitts_and_Nevis",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Lucia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Martin",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Samoa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/San_Marino",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Saudi_Arabia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Scotland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Senegal",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Serbia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Seychelles",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sierra_Leone",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Singapore",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sint_Maarten",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048"
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovakia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Slovenia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Solomon_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Somalia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Africa",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Korea",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/South_Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037"
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Spain",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sri_Lanka",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Sudan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Suriname",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Swaziland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Southern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Switzerland",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Syria",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043"
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/São_Tomé_and_Príncipe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Middle_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Taiwan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0055"
+        "obj" : "http://dbpedia.org/resource/Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tajikistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tanzania",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Thailand",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Bahamas",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/The_Gambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Togo",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Tokelau",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Tonga",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Trinidad_and_Tobago",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tunisia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkey",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turkmenistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Turks_and_Caicos_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Tuvalu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Uganda",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Ukraine",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Arab_Emirates",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/United_Kingdom",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/United_States_Virgin_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Caribbean"
       }, {
         "sub" : "http://dbpedia.org/resource/Uruguay",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Uzbekistan",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-central_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Vanuatu",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Melanesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Venezuela",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/SouthAmerica"
       }, {
         "sub" : "http://dbpedia.org/resource/Vietnam",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/South-Eastern_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Wallis_and_Futuna",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Polynesia"
       }, {
         "sub" : "http://dbpedia.org/resource/Western_Sahara",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Northern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Yemen",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
         "sub" : "http://dbpedia.org/resource/Zambia",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Zimbabwe",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Eastern_Africa"
       }, {
         "sub" : "http://dbpedia.org/resource/Cocos_(Keeling)_Islands",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
@@ -17222,38 +12159,110 @@
       }, {
         "sub" : "http://dbpedia.org/resource/Georgia_(country)",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://dbpedia.org/resource/Western_Asia"
       }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0003",
+        "sub" : "http://purl.obolibrary.org/obo/NCIT_C25464",
         "pred" : "http://purl.obolibrary.org/obo/RO_0001025",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0002"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/BFO_0000050",
       "allValuesFromEdges" : [ {
+        "sub" : "http://dbpedia.org/resource/Caribbean",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Central_America",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
         "sub" : "http://dbpedia.org/resource/Denmark",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Eastern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Melanesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Micronesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Middle_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Northern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Norway",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Polynesia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Oceania"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Scandinavia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-Eastern_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South-central_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/SouthAmerica",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Latin_America_and_the_Caribbean"
+      }, {
+        "sub" : "http://dbpedia.org/resource/South_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Southern_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://dbpedia.org/resource/Sweden",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0288"
+        "obj" : "http://dbpedia.org/resource/Scandinavia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Africa",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Africa"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Asia",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Asia"
+      }, {
+        "sub" : "http://dbpedia.org/resource/Western_Europe",
+        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "obj" : "http://dbpedia.org/resource/Europe"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/BFO_0000002",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
@@ -17281,225 +12290,11 @@
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0002",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/GEO_000000374",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0035",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0036",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0037",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0038",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0039",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0029",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0041",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0042",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0289"
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0043",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0044",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0045",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0046",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0047",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0031",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0048",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0049",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0050",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0033",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
+        "obj" : "http://purl.obolibrary.org/obo/GAZ_00000013"
       }, {
         "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0051",
         "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0052",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0053",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0054",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0032",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0055",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0030",
-        "meta" : {
-          "basicPropertyValues" : [ {
-            "pred" : "http://purl.org/dc/terms/contributor",
-            "val" : "http://e-lico.eu/populous#OPPL_pattern"
-          } ]
-        }
-      }, {
-        "sub" : "http://purl.obolibrary.org/obo/HANCESTRO_0288",
-        "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
-        "obj" : "http://purl.obolibrary.org/obo/HANCESTRO_0045"
+        "obj" : "http://dbpedia.org/resource/Oceania"
       } ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/HANCESTRO_0301",

--- a/hancestro.obo
+++ b/hancestro.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: releases/2023-10-13
+data-version: releases/2024-01-24
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_annotation_extension ""
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_gp2term ""
 subsetdef: http://purl.obolibrary.org/obo/valid_for_go_ontology ""
@@ -12,14 +12,14 @@ property_value: http://purl.org/dc/elements/1.1/title "Human Ancestry Ontology" 
 property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
 property_value: IAO:0000700 HANCESTRO:0004
 property_value: IAO:0000700 HANCESTRO:0304
-property_value: owl:versionInfo "2023-10-13" xsd:string
+property_value: owl:versionInfo "2024-01-24" xsd:string
 
 [Term]
 id: American:Samoa
 name: American Samoa
 xref: GAZ:00003957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: BFO:0000001
@@ -60,20 +60,7 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000003
 name: occurrent
 def: "An entity that has temporal parts and that happens, unfolds or develops through time." []
-is_a: BFO:0000001 ! entity
 relationship: BFO:0000050 BFO:0000003 {all_only="true"} ! part_of occurrent
-property_value: BFO:0000179 "occurrent" xsd:string
-property_value: BFO:0000180 "Occurrent" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players." xsd:string
-property_value: IAO:0000116 "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000006", comment="per discussion with Barry Smith"}
-property_value: IAO:0000116 "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000012"}
-property_value: IAO:0000600 "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/077-002"}
-property_value: IAO:0000601 "b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
-property_value: IAO:0000601 "Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
-property_value: IAO:0000602 "(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/108-001"}
-property_value: IAO:0000602 "(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/079-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000004
@@ -82,8 +69,6 @@ def: "b is an independent continuant = Def. b is a continuant which is such that
 comment: A continuant that is a bearer of quality and realizable entity entities, in which other entities inhere and which itself cannot inhere in anything.
 is_a: BFO:0000002 ! continuant
 disjoint_from: BFO:0000020 ! specifically dependent continuant
-disjoint_from: BFO:0000020 ! specifically dependent continuant
-disjoint_from: BFO:0000031 ! generically dependent continuant
 relationship: BFO:0000050 BFO:0000004 {all_only="true"} ! part_of independent continuant
 property_value: BFO:0000179 "ic" xsd:string
 property_value: BFO:0000180 "IndependentContinuant" xsd:string
@@ -108,15 +93,6 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000006
 name: spatial region
 is_a: BFO:0000141 ! immaterial entity
-property_value: BFO:0000179 "s-region" xsd:string
-property_value: BFO:0000180 "SpatialRegion" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Spatial regions do not participate in processes." xsd:string
-property_value: IAO:0000116 "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000002", comment="per discussion with Barry Smith"}
-property_value: IAO:0000600 "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
-property_value: IAO:0000601 "All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
-property_value: IAO:0000602 "(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/036-001"}
-property_value: IAO:0000602 "(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/035-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000015
@@ -130,18 +106,6 @@ id: BFO:0000016
 name: disposition
 is_a: BFO:0000017 ! realizable entity
 disjoint_from: BFO:0000023 ! role
-property_value: BFO:0000179 "disposition" xsd:string
-property_value: BFO:0000180 "Disposition" xsd:string
-property_value: IAO:0000112 "an atom of element X has the disposition to decay to an atom of element Y" xsd:string
-property_value: IAO:0000112 "certain people have a predisposition to colon cancer" xsd:string
-property_value: IAO:0000112 "children are innately disposed to categorize objects in certain ways." xsd:string
-property_value: IAO:0000112 "the cell wall is disposed to filter chemicals in endocytosis and exocytosis" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type." xsd:string
-property_value: IAO:0000600 "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
-property_value: IAO:0000601 "If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
-property_value: IAO:0000602 "(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/063-002"}
-property_value: IAO:0000602 "(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/062-002"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000017
@@ -150,18 +114,6 @@ def: "A specifically dependent continuant  that inheres in continuant  entities 
 is_a: BFO:0000020 ! specifically dependent continuant
 disjoint_from: BFO:0000019 ! quality
 relationship: BFO:0000050 BFO:0000017 {all_only="true"} ! part_of realizable entity
-property_value: BFO:0000179 "realizable" xsd:string
-property_value: BFO:0000180 "RealizableEntity" xsd:string
-property_value: IAO:0000112 "the disposition of this piece of metal to conduct electricity." xsd:string
-property_value: IAO:0000112 "the disposition of your blood to coagulate" xsd:string
-property_value: IAO:0000112 "the function of your reproductive organs" xsd:string
-property_value: IAO:0000112 "the role of being a doctor" xsd:string
-property_value: IAO:0000112 "the role of this boundary to delineate where Utah and Colorado meet" xsd:string
-property_value: IAO:0000600 "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
-property_value: IAO:0000601 "All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
-property_value: IAO:0000602 "(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/060-002"}
-property_value: IAO:0000602 "(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/058-002"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000019
@@ -185,11 +137,9 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 [Term]
 id: BFO:0000020
 name: specifically dependent continuant
-def: "b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/131-004"}
 def: "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
 comment: A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.
 is_a: BFO:0000002 ! continuant
-disjoint_from: BFO:0000031 ! generically dependent continuant
 relationship: BFO:0000050 BFO:0000020 {all_only="true"} ! part_of specifically dependent continuant
 property_value: BFO:0000179 "sdc" xsd:string
 property_value: BFO:0000180 "SpecificallyDependentContinuant" xsd:string
@@ -205,7 +155,6 @@ property_value: IAO:0000112 "the role of being a doctor" xsd:string
 property_value: IAO:0000112 "the shape of this hole." xsd:string
 property_value: IAO:0000112 "the smell of this portion of mozzarella" xsd:string
 property_value: IAO:0000116 "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc." xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/0000005", comment="per discussion with Barry Smith"}
-property_value: IAO:0000602 "(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/131-004"}
 property_value: IAO:0000602 "(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/050-003"}
 property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
@@ -214,47 +163,11 @@ id: BFO:0000023
 name: role
 def: "A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts." []
 is_a: BFO:0000017 ! realizable entity
-property_value: BFO:0000179 "role" xsd:string
-property_value: BFO:0000180 "Role" xsd:string
-property_value: IAO:0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married." xsd:string
-property_value: IAO:0000112 "the priest role" xsd:string
-property_value: IAO:0000112 "the role of a boundary to demarcate two neighboring administrative territories" xsd:string
-property_value: IAO:0000112 "the role of a building in serving as a military target" xsd:string
-property_value: IAO:0000112 "the role of a stone in marking a property boundary" xsd:string
-property_value: IAO:0000112 "the role of subject in a clinical trial" xsd:string
-property_value: IAO:0000112 "the student role" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives." xsd:string
-property_value: IAO:0000600 "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
-property_value: IAO:0000602 "(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/061-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
-
-[Term]
-id: BFO:0000031
-name: generically dependent continuant
-def: "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])" [] {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
-comment: A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.
-is_a: BFO:0000002 ! continuant
-property_value: BFO:0000179 "gdc" xsd:string
-property_value: BFO:0000180 "GenericallyDependentContinuant" xsd:string
-property_value: IAO:0000112 "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity." xsd:string
-property_value: IAO:0000112 "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop" xsd:string
-property_value: IAO:0000112 "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule." xsd:string
-property_value: IAO:0000602 "(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/074-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000034
 name: function
 is_a: BFO:0000016 ! disposition
-property_value: BFO:0000179 "function" xsd:string
-property_value: BFO:0000180 "Function" xsd:string
-property_value: IAO:0000112 "the function of a hammer to drive in nails" xsd:string
-property_value: IAO:0000112 "the function of a heart pacemaker to regulate the beating of a heart through electricity" xsd:string
-property_value: IAO:0000112 "the function of amylase in saliva to break down starch into sugar" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc." xsd:string
-property_value: IAO:0000600 "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])" xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
-property_value: IAO:0000602 "(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] " xsd:string {IAO:0010000="http://purl.obolibrary.org/obo/bfo/axiom/064-001"}
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: BFO:0000040
@@ -291,102 +204,130 @@ property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 id: BFO:0000141
 name: immaterial entity
 is_a: BFO:0000004 ! independent continuant
-property_value: BFO:0000179 "immaterial" xsd:string
-property_value: BFO:0000180 "ImmaterialEntity" xsd:string
-property_value: IAO:0000116 "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10" xsd:string
-property_value: isDefinedBy http://purl.obolibrary.org/obo/bfo.owl
 
 [Term]
 id: Burkina:Faso
 name: Burkina Faso
 xref: GAZ:00000905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
+
+[Term]
+id: COB:0000032
+name: geographical location
+is_a: BFO:0000141 ! immaterial entity
 
 [Term]
 id: Cape:Verde
 name: Cape Verde
 xref: GAZ:00001227
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Cayman:Islands
 name: Cayman Islands
 xref: GAZ:00003986
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
+
+[Term]
+id: Central:America
+name: Central America
+xref: GAZ:00002891
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: Channel:Islands
 name: Channel Islands
 xref: GAZ:00001539
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: Christmas:Island
 name: Christmas Island
 xref: GAZ:00005915
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: Cook:Islands
 name: Cook Islands
 xref: GAZ:00053798
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: Costa:Rica
 name: Costa Rica
 xref: GAZ:00002901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: Czech:Republic
 name: Czech Republic
 xref: GAZ:00002954
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: Dominican:Republic
 name: Dominican Republic
 xref: GAZ:00003952
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: East:Timor
 name: East Timor
 synonym: "Timor-Leste" EXACT []
 xref: GAZ:00006913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
+
+[Term]
+id: Eastern:Africa
+name: Eastern Africa
+xref: GAZ:00000556
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Eastern:Asia
+name: Eastern Asia
+xref: GAZ:00002471
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Eastern:Europe
+name: Eastern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: El:Salvador
 name: El Salvador
 xref: GAZ:00002935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: Equatorial:Guinea
 name: Equatorial Guinea
 xref: GAZ:00001091
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: Faeroe:Islands
 name: Faeroe Islands
 xref: GAZ:00059206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 property_value: IAO:0000118 "Faroe Islands" xsd:string
 
 [Term]
@@ -394,73 +335,29 @@ id: Falkland:Islands
 name: Falkland Islands
 synonym: "Falkland Islands (Malvinas)" EXACT []
 xref: GAZ:00001412
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: French:Guiana
 name: French Guiana
 xref: GAZ:00002516
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: French:Polynesia
 name: French Polynesia
 xref: GAZ:00002918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
-id: GEO:000000334
-name: subcontinental land mass
-is_a: GEO:000000375 ! land mass
-relationship: BFO:0000137 GEO:000000374 ! continent
-
-[Term]
-id: GEO:000000370
-name: geographical entity
-def: "A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface)." []
-comment: Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.\n\nGenerally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.
-comment: Note that despite the word 'planetary' in 'planetary surface', it refers generally to surface of dwarf planets, asteroids, moons, etc.
-comment: We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.
-comment: We note that the term 'geography' is also applied to the Earth's moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  \n\nThus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc.
-is_a: BFO:0000040 ! material entity
-property_value: IAO:0000111 "geographical entity of astronomical body" xsd:string
-property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
-property_value: IAO:0000117 "Matt Diller" xsd:string
-property_value: IAO:0000117 "William R. Hogan" xsd:string
-
-[Term]
-id: GEO:000000372
-name: geographical region
-def: "A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface." []
-is_a: GEO:000000370 ! geographical entity
-property_value: IAO:0000117 "François Modave" xsd:string
-property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
-property_value: IAO:0000117 "Matt Diller" xsd:string
-property_value: IAO:0000117 "William R. Hogan" xsd:string
-
-[Term]
-id: GEO:000000374
+id: GAZ:00000013
 name: continent
 def: "One of the large, unbroken masses of land into which the Earth's surface is divided." []
 synonym: "major area" EXACT []
-xref: GAZ:00190836
-is_a: GEO:000000375 ! land mass
-
-[Term]
-id: GEO:000000375
-name: land mass
-is_a: GEO:000000372 ! geographical region
-
-[Term]
-id: GEO:000000391
-name: geopoli organization
-name: geopolitical organization
-is_a: OBI:0000245 ! organization
-property_value: IAO:0000111 "geopolitical organization" xsd:string
-property_value: IAO:0000117 "Amanda Hicks" xsd:string
+is_a: COB:0000032 ! geographical location
 
 [Term]
 id: GO:0016301
@@ -469,31 +366,31 @@ id: GO:0016301
 id: Georgia:(country)
 name: Georgia
 xref: GAZ:00004942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Guinea:Bissau
 name: Guinea-Bissau
 xref: GAZ:00000910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: HANCESTRO:0002
 name: region
 def: "Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable." []
 synonym: "geographical area" EXACT []
-is_a: GEO:000000334 ! subcontinental land mass
-relationship: BFO:0000050 GEO:000000374 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of continent
+is_a: COB:0000032 ! geographical location
+relationship: BFO:0000050 GAZ:00000013 {all_only="true"} ! part_of continent
 
 [Term]
 id: HANCESTRO:0003
-name: country
+name: obsolete country
 def: "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states." []
-is_a: GEO:000000391 ! geopoli organization
-relationship: RO:0001025 HANCESTRO:0002 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in region
 property_value: IAO:0000119 "NCIT:C25464" xsd:string
+is_obsolete: true
+replaced_by: http://purl.obolibrary.org/obo/NCIT_C25464
 
 [Term]
 id: HANCESTRO:0004
@@ -646,174 +543,159 @@ is_a: HANCESTRO:0021 ! Chinese
 
 [Term]
 id: HANCESTRO:0029
-name: Africa
-xref: GAZ:00000457
-is_a: GEO:000000374 ! continent
-disjoint_from: HANCESTRO:0030 ! Asia
+name: obsolete Africa
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Africa
 
 [Term]
 id: HANCESTRO:0030
-name: Asia
-xref: GAZ:00000465
-is_a: GEO:000000374 ! continent
+name: obsolete Asia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Asia
 
 [Term]
 id: HANCESTRO:0031
-name: Europe
-xref: GAZ:00000464
-is_a: GEO:000000374 ! continent
+name: obsolete Europe
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Europe
 
 [Term]
 id: HANCESTRO:0032
-name: Oceania
-xref: GAZ:00000468
-is_a: GEO:000000374 ! continent
+name: obsolete Oceania
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Oceania
 
 [Term]
 id: HANCESTRO:0033
-name: Latin America and the Caribbean
-xref: GAZ:00000459
-is_a: GEO:000000374 ! continent
+name: obsolete Latin America and the Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
 
 [Term]
 id: HANCESTRO:0034
-name: Northern America
-xref: GAZ:00000458
-is_a: GEO:000000374 ! continent
+name: obsolete Northern America
+is_obsolete: true
+replaced_by: Northern:America
 
 [Term]
 id: HANCESTRO:0035
-name: Eastern Africa
-xref: GAZ:00000556
-is_a: HANCESTRO:0002 ! region
-disjoint_from: HANCESTRO:0036 ! Middle Africa
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Eastern Africa
+is_obsolete: true
+replaced_by: Eastern:Africa
 
 [Term]
 id: HANCESTRO:0036
-name: Middle Africa
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Middle Africa
+is_obsolete: true
+replaced_by: Middle:Africa
 
 [Term]
 id: HANCESTRO:0037
-name: Northern Africa
-xref: GAZ:00000555
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Northern Africa
+is_obsolete: true
+replaced_by: Northern:Africa
 
 [Term]
 id: HANCESTRO:0038
-name: Southern Africa
-xref: GAZ:00000553
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Southern Africa
+is_obsolete: true
+replaced_by: Southern:Africa
 
 [Term]
 id: HANCESTRO:0039
-name: Western Africa
-xref: GAZ:00000554
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0029 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Africa
+name: obsolete Western Africa
+is_obsolete: true
+replaced_by: Western:Africa
 
 [Term]
 id: HANCESTRO:0041
-name: South-Central Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South Central Asia
+is_obsolete: true
+replaced_by: South-central:Asia
 
 [Term]
 id: HANCESTRO:0042
-name: South-Eastern Asia
-xref: GAZ:00000559
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
-relationship: BFO:0000050 HANCESTRO:0289 {all_only="true"} ! part_of South Asia
+name: obsolete South-Eastern Asia
+is_obsolete: true
+replaced_by: South-Eastern:Asia
 
 [Term]
 id: HANCESTRO:0043
-name: Western Asia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Western Asia
+is_obsolete: true
+replaced_by: Western:Asia
 
 [Term]
 id: HANCESTRO:0044
-name: Eastern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Eastern Europe
+is_obsolete: true
+replaced_by: Eastern:Europe
 
 [Term]
 id: HANCESTRO:0045
-name: Northern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Northern Europe
+is_obsolete: true
+replaced_by: Northern:Europe
 
 [Term]
 id: HANCESTRO:0046
-name: Southern Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Southern Europe
+is_obsolete: true
+replaced_by: Southern:Europe
 
 [Term]
 id: HANCESTRO:0047
-name: Western Europe
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0031 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Europe
+name: obsolete Western Europe
+is_obsolete: true
+replaced_by: Western:Europe
 
 [Term]
 id: HANCESTRO:0048
-name: Caribbean
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Caribbean
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Caribbean
 
 [Term]
 id: HANCESTRO:0049
-name: South America
-xref: GAZ:00000459
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete South America
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/SouthAmerica
 
 [Term]
 id: HANCESTRO:0050
-name: Central America
-xref: GAZ:00002891
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0033 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Latin America and the Caribbean
+name: obsolete Central America
+is_obsolete: true
+replaced_by: Central:America
 
 [Term]
 id: HANCESTRO:0051
 name: Australia/New Zealand
 is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: HANCESTRO:0052
-name: Melanesia
-xref: GAZ:00005860
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Melanesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Melanesia
 
 [Term]
 id: HANCESTRO:0053
-name: Micronesia
-xref: GAZ:00005862
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Micronesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Micronesia
 
 [Term]
 id: HANCESTRO:0054
-name: Polynesia
-xref: GAZ:00005861
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0032 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Oceania
+name: obsolete Polynesia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Polynesia
 
 [Term]
 id: HANCESTRO:0055
-name: Eastern Asia
-xref: GAZ:00002471
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0030 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! part_of Asia
+name: obsolete Eastern Asia
+is_obsolete: true
+replaced_by: Eastern:Asia
 
 [Term]
 id: HANCESTRO:0286
@@ -823,15 +705,15 @@ is_a: HANCESTRO:0008 ! Asian
 
 [Term]
 id: HANCESTRO:0288
-name: Scandinavia
-is_a: HANCESTRO:0002 ! region
-relationship: BFO:0000050 HANCESTRO:0045 {all_only="true"} ! part_of Northern Europe
+name: obsolete Scandinavia
+is_obsolete: true
+replaced_by: http://dbpedia.org/resource/Scandinavia
 
 [Term]
 id: HANCESTRO:0289
-name: South Asia
-xref: GAZ:00002472
-is_a: HANCESTRO:0002 ! region
+name: obsolete South Asia
+is_obsolete: true
+replaced_by: South:Asia
 
 [Term]
 id: HANCESTRO:0290
@@ -865,7 +747,7 @@ is_a: HANCESTRO:0304 ! ancestry status
 id: HANCESTRO:0307
 name: Italian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Italy
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Italy ! isDemonymOf Italy
 
 [Term]
 id: HANCESTRO:0309
@@ -962,7 +844,7 @@ is_a: HANCESTRO:0005 ! European
 id: HANCESTRO:0321
 name: Finnish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Finland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Finland ! isDemonymOf Finland
 
 [Term]
 id: HANCESTRO:0322
@@ -995,1323 +877,1323 @@ is_obsolete: true
 [Term]
 id: HANCESTRO:0331
 name: Sudanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sudan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sudan ! isDemonymOf Sudan
 
 [Term]
 id: HANCESTRO:0332
 name: Sahrawi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Western:Sahara {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Western Sahara
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Western:Sahara ! isDemonymOf Western Sahara
 
 [Term]
 id: HANCESTRO:0333
 name: Anguillan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Anguilla
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Anguilla ! isDemonymOf Anguilla
 
 [Term]
 id: HANCESTRO:0334
 name: Antiguan or Barbudan
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Antigua and Barbuda
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Antigua_and_Barbuda ! isDemonymOf Antigua and Barbuda
 
 [Term]
 id: HANCESTRO:0335
 name: Barbadian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Barbados
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Barbados ! isDemonymOf Barbados
 
 [Term]
 id: HANCESTRO:0336
 name: Haitian
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Haiti
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Haiti ! isDemonymOf Haiti
 
 [Term]
 id: HANCESTRO:0337
 name: Jamaican
-is_a: HANCESTRO:0016 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! African American or Afro-Caribbean
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jamaica
+is_a: HANCESTRO:0016 ! African American or Afro-Caribbean
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jamaica ! isDemonymOf Jamaica
 
 [Term]
 id: HANCESTRO:0338
 name: Tajikistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tajikistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tajikistan ! isDemonymOf Tajikistan
 
 [Term]
 id: HANCESTRO:0339
 name: Turkmen
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkmenistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkmenistan ! isDemonymOf Turkmenistan
 
 [Term]
 id: HANCESTRO:0340
 name: Uzbekistani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uzbekistan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uzbekistan ! isDemonymOf Uzbekistan
 
 [Term]
 id: HANCESTRO:0341
 name: Afghan
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Afghanistan
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Afghanistan ! isDemonymOf Afghanistan
 
 [Term]
 id: HANCESTRO:0342
 name: Kazakhstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kazakhstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kazakhstan ! isDemonymOf Kazakhstan
 
 [Term]
 id: HANCESTRO:0343
 name: Kyrgyzstani
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kyrgyzstan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kyrgyzstan ! isDemonymOf Kyrgyzstan
 
 [Term]
 id: HANCESTRO:0344
 name: Albanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Albania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Albania ! isDemonymOf Albania
 
 [Term]
 id: HANCESTRO:0345
 name: Andorran
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Andorra
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Andorra ! isDemonymOf Andorra
 
 [Term]
 id: HANCESTRO:0346
 name: Australian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Australia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Australia ! isDemonymOf Australia
 
 [Term]
 id: HANCESTRO:0347
 name: Austrian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Austria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Austria ! isDemonymOf Austria
 
 [Term]
 id: HANCESTRO:0348
 name: Belarusian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belarus
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belarus ! isDemonymOf Belarus
 
 [Term]
 id: HANCESTRO:0349
 name: Belgian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belgium
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belgium ! isDemonymOf Belgium
 
 [Term]
 id: HANCESTRO:0350
 name: Bermudian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bermuda
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bermuda ! isDemonymOf Bermuda
 
 [Term]
 id: HANCESTRO:0351
 name: Bosnian or Herzegovinian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bosnia and Herzegovina
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bosnia_and_Herzegovina ! isDemonymOf Bosnia and Herzegovina
 
 [Term]
 id: HANCESTRO:0352
 name: Brazilian
 is_a: HANCESTRO:0014 ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brazil
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brazil ! isDemonymOf Brazil
 
 [Term]
 id: HANCESTRO:0353
 name: Bulgarian
 is_a: HANCESTRO:0018 ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bulgaria
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bulgaria ! isDemonymOf Bulgaria
 
 [Term]
 id: HANCESTRO:0354
 name: Canadian
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Canada
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Canada ! isDemonymOf Canada
 
 [Term]
 id: HANCESTRO:0355
 name: Channel Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Channel:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Channel Islands
+relationship: HANCESTRO:0330 Channel:Islands ! isDemonymOf Channel Islands
 
 [Term]
 id: HANCESTRO:0356
 name: Chilean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chile
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chile ! isDemonymOf Chile
 
 [Term]
 id: HANCESTRO:0357
 name: Croatian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Croatia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Croatia ! isDemonymOf Croatia
 
 [Term]
 id: HANCESTRO:0358
 name: Czech
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Czech:Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Czech Republic
+relationship: HANCESTRO:0330 Czech:Republic ! isDemonymOf Czech Republic
 
 [Term]
 id: HANCESTRO:0359
 name: Danish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Denmark
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Denmark ! isDemonymOf Denmark
 
 [Term]
 id: HANCESTRO:0360
 name: Estonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Estonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Estonia ! isDemonymOf Estonia
 
 [Term]
 id: HANCESTRO:0361
 name: Faroese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Faeroe:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Faeroe Islands
+relationship: HANCESTRO:0330 Faeroe:Islands ! isDemonymOf Faeroe Islands
 
 [Term]
 id: HANCESTRO:0362
 name: Falkland Islander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Falkland:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Falkland Islands
+relationship: HANCESTRO:0330 Falkland:Islands ! isDemonymOf Falkland Islands
 
 [Term]
 id: HANCESTRO:0363
 name: French
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/France {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf France
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/France ! isDemonymOf France
 
 [Term]
 id: HANCESTRO:0364
 name: German
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Germany
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Germany ! isDemonymOf Germany
 
 [Term]
 id: HANCESTRO:0365
 name: Gibraltarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gibraltar
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gibraltar ! isDemonymOf Gibraltar
 
 [Term]
 id: HANCESTRO:0366
 name: Greek
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greece
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greece ! isDemonymOf Greece
 
 [Term]
 id: HANCESTRO:0367
 name: Greenlander
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Greenland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Greenland ! isDemonymOf Greenland
 
 [Term]
 id: HANCESTRO:0368
 name: Hungarian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Hungary
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Hungary ! isDemonymOf Hungary
 
 [Term]
 id: HANCESTRO:0369
 name: Icelandic
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iceland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iceland ! isDemonymOf Iceland
 
 [Term]
 id: HANCESTRO:0370
 name: Manx
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Isle of Man
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Isle_of_Man ! isDemonymOf Isle of Man
 
 [Term]
 id: HANCESTRO:0371
 name: Latvian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Latvia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Latvia ! isDemonymOf Latvia
 
 [Term]
 id: HANCESTRO:0372
 name: Liechtensteiner
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liechtenstein
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liechtenstein ! isDemonymOf Liechtenstein
 
 [Term]
 id: HANCESTRO:0373
 name: Lithuanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lithuania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lithuania ! isDemonymOf Lithuania
 
 [Term]
 id: HANCESTRO:0374
 name: Luxembourgish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Luxembourg
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Luxembourg ! isDemonymOf Luxembourg
 
 [Term]
 id: HANCESTRO:0375
 name: Maltese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malta
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malta ! isDemonymOf Malta
 
 [Term]
 id: HANCESTRO:0376
 name: Monegasque
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Monaco
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Monaco ! isDemonymOf Monaco
 
 [Term]
 id: HANCESTRO:0377
 name: Montenegrin
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montenegro
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montenegro ! isDemonymOf Montenegro
 
 [Term]
 id: HANCESTRO:0378
 name: New Zealandish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Zealand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Zealand
+relationship: HANCESTRO:0330 New:Zealand ! isDemonymOf New Zealand
 
 [Term]
 id: HANCESTRO:0379
 name: Norfolk Islander
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
+is_a: HANCESTRO:0018 ! uncategorised population
 is_a: HANCESTRO:0290 ! genetically isolated population
 relationship: HANCESTRO:0301 HANCESTRO:0305 {all_only="true"} ! hasAncestryStatus genetically isolated ancestry
-relationship: HANCESTRO:0330 Norfolk:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norfolk Island
+relationship: HANCESTRO:0330 Norfolk:Island ! isDemonymOf Norfolk Island
 
 [Term]
 id: HANCESTRO:0380
 name: Norwegian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Norway
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Norway ! isDemonymOf Norway
 
 [Term]
 id: HANCESTRO:0381
 name: Polish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Poland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Poland ! isDemonymOf Poland
 
 [Term]
 id: HANCESTRO:0382
 name: Portugese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Portugal
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Portugal ! isDemonymOf Portugal
 
 [Term]
 id: HANCESTRO:0383
 name: Irish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Ireland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Ireland ! isDemonymOf Republic of Ireland
 
 [Term]
 id: HANCESTRO:0384
 name: Moldovan
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Moldova
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Moldova ! isDemonymOf Moldova
 
 [Term]
 id: HANCESTRO:0385
 name: Romanian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Romania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Romania ! isDemonymOf Romania
 
 [Term]
 id: HANCESTRO:0386
 name: Russian
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Russia
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Russia ! isDemonymOf Russia
 
 [Term]
 id: HANCESTRO:0387
 name: Saint-Pierrais or Miquelonnais
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Pierre and Miquelon
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Pierre_and_Miquelon ! isDemonymOf Saint Pierre and Miquelon
 
 [Term]
 id: HANCESTRO:0388
 name: Sammarinese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 San:Marino {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf San Marino
+relationship: HANCESTRO:0330 San:Marino ! isDemonymOf San Marino
 
 [Term]
 id: HANCESTRO:0389
 name: Serb
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Serbia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Serbia ! isDemonymOf Serbia
 
 [Term]
 id: HANCESTRO:0390
 name: Slovak
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovakia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovakia ! isDemonymOf Slovakia
 
 [Term]
 id: HANCESTRO:0391
 name: Slovene
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Slovenia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Slovenia ! isDemonymOf Slovenia
 
 [Term]
 id: HANCESTRO:0392
 name: Spanish
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Spain
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Spain ! isDemonymOf Spain
 
 [Term]
 id: HANCESTRO:0393
 name: Swedish
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sweden
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Sweden ! isDemonymOf Sweden
 
 [Term]
 id: HANCESTRO:0394
 name: Swiss
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Switzerland
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Switzerland ! isDemonymOf Switzerland
 
 [Term]
 id: HANCESTRO:0395
 name: Macedonian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of Macedonia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_Macedonia ! isDemonymOf Republic of Macedonia
 
 [Term]
 id: HANCESTRO:0396
 name: Ukrainian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ukraine
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ukraine ! isDemonymOf Ukraine
 
 [Term]
 id: HANCESTRO:0397
 name: Argentine
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Argentina
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Argentina ! isDemonymOf Argentina
 
 [Term]
 id: HANCESTRO:0398
 name: Bahamian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 The:Bahamas {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Bahamas
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 The:Bahamas ! isDemonymOf The Bahamas
 
 [Term]
 id: HANCESTRO:0399
 name: Belizean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Belize
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Belize ! isDemonymOf Belize
 
 [Term]
 id: HANCESTRO:0400
 name: Bolivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bolivia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bolivia ! isDemonymOf Bolivia
 
 [Term]
 id: HANCESTRO:0401
 name: British Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf British Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/British_Virgin_Islands ! isDemonymOf British Virgin Islands
 
 [Term]
 id: HANCESTRO:0402
 name: Caymanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cayman:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cayman Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cayman:Islands ! isDemonymOf Cayman Islands
 
 [Term]
 id: HANCESTRO:0403
 name: Colombian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Colombia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Colombia ! isDemonymOf Colombia
 
 [Term]
 id: HANCESTRO:0404
 name: Costa Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Costa:Rica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Costa Rica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Costa:Rica ! isDemonymOf Costa Rica
 
 [Term]
 id: HANCESTRO:0405
 name: Cuban
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cuba
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cuba ! isDemonymOf Cuba
 
 [Term]
 id: HANCESTRO:0406
 name: Dominican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Dominica
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Dominica ! isDemonymOf Dominica
 
 [Term]
 id: HANCESTRO:0407
 name: Ecuadorian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ecuador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ecuador ! isDemonymOf Ecuador
 
 [Term]
 id: HANCESTRO:0408
 name: Salvadoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 El:Salvador {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf El Salvador
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 El:Salvador ! isDemonymOf El Salvador
 
 [Term]
 id: HANCESTRO:0409
 name: French Guianese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Guiana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Guiana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Guiana ! isDemonymOf French Guiana
 
 [Term]
 id: HANCESTRO:0410
 name: Grenadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Grenada
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Grenada ! isDemonymOf Grenada
 
 [Term]
 id: HANCESTRO:0411
 name: Guatemalan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guatemala
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guatemala ! isDemonymOf Guatemala
 
 [Term]
 id: HANCESTRO:0412
 name: Guyanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guyana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guyana ! isDemonymOf Guyana
 
 [Term]
 id: HANCESTRO:0413
 name: Honduran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Honduras
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Honduras ! isDemonymOf Honduras
 
 [Term]
 id: HANCESTRO:0414
 name: Martinican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Martinique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Martinique ! isDemonymOf Martinique
 
 [Term]
 id: HANCESTRO:0415
 name: Mexican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mexico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mexico ! isDemonymOf Mexico
 
 [Term]
 id: HANCESTRO:0416
 name: Montserratian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Montserrat
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Montserrat ! isDemonymOf Montserrat
 
 [Term]
 id: HANCESTRO:0417
 name: Nicaraguan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nicaragua
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nicaragua ! isDemonymOf Nicaragua
 
 [Term]
 id: HANCESTRO:0418
 name: Panamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Panama
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Panama ! isDemonymOf Panama
 
 [Term]
 id: HANCESTRO:0419
 name: Paraguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Paraguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Paraguay ! isDemonymOf Paraguay
 
 [Term]
 id: HANCESTRO:0420
 name: Peruvian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Peru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Peru ! isDemonymOf Peru
 
 [Term]
 id: HANCESTRO:0421
 name: Puerto Rican
-is_a: HANCESTRO:0014 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Hispanic or Latin American
-relationship: HANCESTRO:0330 Puerto:Rico {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Puerto Rico
+is_a: HANCESTRO:0014 ! Hispanic or Latin American
+relationship: HANCESTRO:0330 Puerto:Rico ! isDemonymOf Puerto Rico
 
 [Term]
 id: HANCESTRO:0422
 name: Kittitian or Nevisian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Kitts and Nevis
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Kitts_and_Nevis ! isDemonymOf Saint Kitts and Nevis
 
 [Term]
 id: HANCESTRO:0423
 name: Saint Lucian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Lucia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Lucia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Lucia ! isDemonymOf Saint Lucia
 
 [Term]
 id: HANCESTRO:0424
 name: Saint Vincentian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Vincent and the Grenadines
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines ! isDemonymOf Saint Vincent and the Grenadines
 
 [Term]
 id: HANCESTRO:0425
 name: Surinamese
 synonym: "Surinamer" EXACT []
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Suriname
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Suriname ! isDemonymOf Suriname
 
 [Term]
 id: HANCESTRO:0426
 name: Trinidadian or Tobagonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Trinidad and Tobago
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Trinidad_and_Tobago ! isDemonymOf Trinidad and Tobago
 
 [Term]
 id: HANCESTRO:0427
 name: Turks and Caicos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turks and Caicos Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turks_and_Caicos_Islands ! isDemonymOf Turks and Caicos Islands
 
 [Term]
 id: HANCESTRO:0428
 name: Virgin Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States Virgin Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_States_Virgin_Islands ! isDemonymOf United States Virgin Islands
 
 [Term]
 id: HANCESTRO:0429
 name: Uruguayan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uruguay
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uruguay ! isDemonymOf Uruguay
 
 [Term]
 id: HANCESTRO:0430
 name: Venezuelan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Venezuela
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Venezuela ! isDemonymOf Venezuela
 
 [Term]
 id: HANCESTRO:0431
 name: Algerian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Algeria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Algeria ! isDemonymOf Algeria
 
 [Term]
 id: HANCESTRO:0432
 name: Armenian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Armenia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Armenia ! isDemonymOf Armenia
 
 [Term]
 id: HANCESTRO:0433
 name: Azerbaijani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Azerbaijan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Azerbaijan ! isDemonymOf Azerbaijan
 
 [Term]
 id: HANCESTRO:0434
 name: Bahraini
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bahrain
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bahrain ! isDemonymOf Bahrain
 
 [Term]
 id: HANCESTRO:0435
 name: Cypriote
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cyprus
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cyprus ! isDemonymOf Cyprus
 
 [Term]
 id: HANCESTRO:0436
 name: Egyptian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Egypt
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Egypt ! isDemonymOf Egypt
 
 [Term]
 id: HANCESTRO:0437
 name: Georgian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Georgia:(country) {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Georgia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Georgia:(country) ! isDemonymOf Georgia
 
 [Term]
 id: HANCESTRO:0438
 name: Iranian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iran
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iran ! isDemonymOf Iran
 
 [Term]
 id: HANCESTRO:0439
 name: Iraqi
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Iraq
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Iraq ! isDemonymOf Iraq
 
 [Term]
 id: HANCESTRO:0440
 name: Israeli
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Israel
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Israel ! isDemonymOf Israel
 
 [Term]
 id: HANCESTRO:0441
 name: Jordanian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Jordan
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Jordan ! isDemonymOf Jordan
 
 [Term]
 id: HANCESTRO:0442
 name: Kuwaiti
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kuwait
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kuwait ! isDemonymOf Kuwait
 
 [Term]
 id: HANCESTRO:0443
 name: Lebanese
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lebanon
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lebanon ! isDemonymOf Lebanon
 
 [Term]
 id: HANCESTRO:0444
 name: Libyan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Libya
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Libya ! isDemonymOf Libya
 
 [Term]
 id: HANCESTRO:0445
 name: Moroccan
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Morocco
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Morocco ! isDemonymOf Morocco
 
 [Term]
 id: HANCESTRO:0446
 name: Palestinian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Palestinian:territories {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palestinian Territories
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Palestinian:territories ! isDemonymOf Palestinian Territories
 
 [Term]
 id: HANCESTRO:0447
 name: Omani
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Oman
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Oman ! isDemonymOf Oman
 
 [Term]
 id: HANCESTRO:0448
 name: Qatari
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Qatar
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Qatar ! isDemonymOf Qatar
 
 [Term]
 id: HANCESTRO:0449
 name: Saudi
 synonym: "Saudi Arab" EXACT []
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 Saudi:Arabia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saudi Arabia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 Saudi:Arabia ! isDemonymOf Saudi Arabia
 
 [Term]
 id: HANCESTRO:0450
 name: Tunisian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tunisia
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tunisia ! isDemonymOf Tunisia
 
 [Term]
 id: HANCESTRO:0451
 name: Turkish
-is_a: HANCESTRO:0018 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! uncategorised population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Turkey
+is_a: HANCESTRO:0018 ! uncategorised population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Turkey ! isDemonymOf Turkey
 
 [Term]
 id: HANCESTRO:0452
 name: Emirati
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Arab Emirates
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/United_Arab_Emirates ! isDemonymOf United Arab Emirates
 
 [Term]
 id: HANCESTRO:0453
 name: Yemeni
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Yemen
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Yemen ! isDemonymOf Yemen
 
 [Term]
 id: HANCESTRO:0454
 name: Aruban
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Aruba
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Aruba ! isDemonymOf Aruba
 
 [Term]
 id: HANCESTRO:0455
 name: Christmas Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Christmas:Island {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Christmas Island
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Christmas:Island ! isDemonymOf Christmas Island
 
 [Term]
 id: HANCESTRO:0456
 name: Cocos Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cocos (Keeling) Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cocos_(Keeling)_Islands ! isDemonymOf Cocos (Keeling) Islands
 
 [Term]
 id: HANCESTRO:0457
 name: Curacaoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Curacao
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Curacao ! isDemonymOf Curacao
 
 [Term]
 id: HANCESTRO:0458
 name: Kosovar
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kosovo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kosovo ! isDemonymOf Kosovo
 
 [Term]
 id: HANCESTRO:0459
 name: Northern Mariana Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Northern Mariana Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Northern_Mariana_Islands ! isDemonymOf Northern Mariana Islands
 
 [Term]
 id: HANCESTRO:0460
 name: South Sudanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Sudan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Sudan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Sudan ! isDemonymOf South Sudan
 
 [Term]
 id: HANCESTRO:0461
 name: Syrian
-is_a: HANCESTRO:0015 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Syria
+is_a: HANCESTRO:0015 ! Greater Middle Eastern  (Middle Eastern or North African or Persian)
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Syria ! isDemonymOf Syria
 
 [Term]
 id: HANCESTRO:0462
 name: British
 is_a: HANCESTRO:0005 ! European
-relationship: HANCESTRO:0330 United:Kingdom {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United Kingdom
+relationship: HANCESTRO:0330 United:Kingdom ! isDemonymOf United Kingdom
 
 [Term]
 id: HANCESTRO:0463
 name: American
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 United:States {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf United States
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 United:States ! isDemonymOf United States
 
 [Term]
 id: HANCESTRO:0464
 name: American Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 American:Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf American Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 American:Samoa ! isDemonymOf American Samoa
 
 [Term]
 id: HANCESTRO:0465
 name: Cook Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Cook:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cook Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Cook:Islands ! isDemonymOf Cook Islands
 
 [Term]
 id: HANCESTRO:0466
 name: Fijian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Fiji
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Fiji ! isDemonymOf Fiji
 
 [Term]
 id: HANCESTRO:0467
 name: French Polynesian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 French:Polynesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf French Polynesia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 French:Polynesia ! isDemonymOf French Polynesia
 
 [Term]
 id: HANCESTRO:0468
 name: Guamanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guam
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guam ! isDemonymOf Guam
 
 [Term]
 id: HANCESTRO:0469
 name: I-Kiribati
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kiribati
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kiribati ! isDemonymOf Kiribati
 
 [Term]
 id: HANCESTRO:0470
 name: Marshallese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Marshall:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Marshall Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Marshall:Islands ! isDemonymOf Marshall Islands
 
 [Term]
 id: HANCESTRO:0471
 name: Micronesian
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Micronesia (Federated States of)
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Federated_States_of_Micronesia ! isDemonymOf Micronesia (Federated States of)
 
 [Term]
 id: HANCESTRO:0472
 name: Nauruan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nauru
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nauru ! isDemonymOf Nauru
 
 [Term]
 id: HANCESTRO:0473
 name: New Caledonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 New:Caledonia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf New Caledonia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 New:Caledonia ! isDemonymOf New Caledonia
 
 [Term]
 id: HANCESTRO:0474
 name: Niuean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niue
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niue ! isDemonymOf Niue
 
 [Term]
 id: HANCESTRO:0475
 name: Palauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Palau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Palau ! isDemonymOf Palau
 
 [Term]
 id: HANCESTRO:0476
 name: Papua New Guinean
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Papua New Guinea
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Papua_New_Guinea ! isDemonymOf Papua New Guinea
 
 [Term]
 id: HANCESTRO:0477
 name: Pitcairn Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Pitcairn:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pitcairn Islands
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Pitcairn:Islands ! isDemonymOf Pitcairn Islands
 
 [Term]
 id: HANCESTRO:0478
 name: Samoan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Samoa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Samoa ! isDemonymOf Samoa
 
 [Term]
 id: HANCESTRO:0479
 name: Solomon Islander
-is_a: HANCESTRO:0017 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Oceanian
-relationship: HANCESTRO:0330 Solomon:Islands {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Solomon Islands
+is_a: HANCESTRO:0017 ! Oceanian
+relationship: HANCESTRO:0330 Solomon:Islands ! isDemonymOf Solomon Islands
 
 [Term]
 id: HANCESTRO:0480
 name: Tokelauan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tokelau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tokelau ! isDemonymOf Tokelau
 
 [Term]
 id: HANCESTRO:0481
 name: Tongan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tonga
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tonga ! isDemonymOf Tonga
 
 [Term]
 id: HANCESTRO:0482
 name: Tuvaluan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tuvalu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tuvalu ! isDemonymOf Tuvalu
 
 [Term]
 id: HANCESTRO:0483
 name: Ni-Vanuato
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vanuatu
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vanuatu ! isDemonymOf Vanuatu
 
 [Term]
 id: HANCESTRO:0484
 name: Wallis and Futuna Islander
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Wallis and Futuna
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Wallis_and_Futuna ! isDemonymOf Wallis and Futuna
 
 [Term]
 id: HANCESTRO:0485
 name: Bangladeshi
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bangladesh
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bangladesh ! isDemonymOf Bangladesh
 
 [Term]
 id: HANCESTRO:0486
 name: Bhutanese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Bhutan
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Bhutan ! isDemonymOf Bhutan
 
 [Term]
 id: HANCESTRO:0487
 name: Indian
 synonym: "Asian Indian" EXACT []
 synonym: "Indian Asian" EXACT []
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/India {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf India
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/India ! isDemonymOf India
 
 [Term]
 id: HANCESTRO:0488
 name: Maldivian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Maldives
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Maldives ! isDemonymOf Maldives
 
 [Term]
 id: HANCESTRO:0489
 name: Nepalese
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nepal
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nepal ! isDemonymOf Nepal
 
 [Term]
 id: HANCESTRO:0490
 name: Pakistani
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Pakistan
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Pakistan ! isDemonymOf Pakistan
 
 [Term]
 id: HANCESTRO:0491
 name: Sri Lankan
-is_a: HANCESTRO:0006 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South Asian
-relationship: HANCESTRO:0330 Sri:Lanka {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sri Lanka
+is_a: HANCESTRO:0006 ! South Asian
+relationship: HANCESTRO:0330 Sri:Lanka ! isDemonymOf Sri Lanka
 
 [Term]
 id: HANCESTRO:0492
 name: Bruneian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Brunei
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Brunei ! isDemonymOf Brunei
 
 [Term]
 id: HANCESTRO:0493
 name: Cambodian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cambodia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cambodia ! isDemonymOf Cambodia
 
 [Term]
 id: HANCESTRO:0494
 name: Indonesian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Indonesia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Indonesia ! isDemonymOf Indonesia
 
 [Term]
 id: HANCESTRO:0495
 name: Lao
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Laos
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Laos ! isDemonymOf Laos
 
 [Term]
 id: HANCESTRO:0496
 name: Malaysian
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malaysia
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malaysia ! isDemonymOf Malaysia
 
 [Term]
 id: HANCESTRO:0497
 name: Burmese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Myanmar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Myanmar ! isDemonymOf Myanmar
 
 [Term]
 id: HANCESTRO:0498
 name: Filipino
-is_a: HANCESTRO:0008 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Philippines
+is_a: HANCESTRO:0008 ! Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Philippines ! isDemonymOf Philippines
 
 [Term]
 id: HANCESTRO:0500
 name: Thai
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Thailand
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Thailand ! isDemonymOf Thailand
 
 [Term]
 id: HANCESTRO:0501
 name: Timorese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 East:Timor {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf East Timor
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 East:Timor ! isDemonymOf East Timor
 
 [Term]
 id: HANCESTRO:0502
 name: Vietnamese
-is_a: HANCESTRO:0007 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! South East Asian
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Vietnam
+is_a: HANCESTRO:0007 ! South East Asian
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Vietnam ! isDemonymOf Vietnam
 
 [Term]
 id: HANCESTRO:0503
 name: Cameroonian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cameroon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Cameroon ! isDemonymOf Cameroon
 
 [Term]
 id: HANCESTRO:0504
 name: Cape Verdean
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 Cape:Verde {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Cape Verde
+relationship: HANCESTRO:0330 Cape:Verde ! isDemonymOf Cape Verde
 
 [Term]
 id: HANCESTRO:0505
 name: Chadian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Chad
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Chad ! isDemonymOf Chad
 
 [Term]
 id: HANCESTRO:0506
 name: Ethiopian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ethiopia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ethiopia ! isDemonymOf Ethiopia
 
 [Term]
 id: HANCESTRO:0507
 name: Kenyan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Kenya
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Kenya ! isDemonymOf Kenya
 
 [Term]
 id: HANCESTRO:0508
 name: Liberian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Liberia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Liberia ! isDemonymOf Liberia
 
 [Term]
 id: HANCESTRO:0509
 name: Malagasy
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Madagascar
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Madagascar ! isDemonymOf Madagascar
 
 [Term]
 id: HANCESTRO:0510
 name: Mauritanian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritania
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauretania ! isDemonymOf Mauritania
 
 [Term]
 id: HANCESTRO:0511
 name: Mauritian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mauritius
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mauritius ! isDemonymOf Mauritius
 
 [Term]
 id: HANCESTRO:0512
 name: Mahoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mayotte
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mayotte ! isDemonymOf Mayotte
 
 [Term]
 id: HANCESTRO:0513
 name: Namibian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Namibia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Namibia ! isDemonymOf Namibia
 
 [Term]
 id: HANCESTRO:0514
 name: Sao Tomean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf São Tomé and Príncipe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/São_Tomé_and_Príncipe ! isDemonymOf São Tomé and Príncipe
 
 [Term]
 id: HANCESTRO:0515
 name: Senegalese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Senegal
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Senegal ! isDemonymOf Senegal
 
 [Term]
 id: HANCESTRO:0516
 name: Seychellois
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Seychelles
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Seychelles ! isDemonymOf Seychelles
 
 [Term]
 id: HANCESTRO:0517
 name: Sierra Leonean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Sierra:Leone {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Sierra Leone
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Sierra:Leone ! isDemonymOf Sierra Leone
 
 [Term]
 id: HANCESTRO:0518
 name: Somali
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Somalia
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Somalia ! isDemonymOf Somalia
 
 [Term]
 id: HANCESTRO:0519
 name: South African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 South:Africa {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf South Africa
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 South:Africa ! isDemonymOf South Africa
 
 [Term]
 id: HANCESTRO:0520
 name: St. Helenian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Saint:Helena {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Saint Helena
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Saint:Helena ! isDemonymOf Saint Helena
 
 [Term]
 id: HANCESTRO:0521
 name: Ugandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Uganda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Uganda ! isDemonymOf Uganda
 
 [Term]
 id: HANCESTRO:0522
 name: Angolan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Angola
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Angola ! isDemonymOf Angola
 
 [Term]
 id: HANCESTRO:0523
 name: Beninese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Benin
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Benin ! isDemonymOf Benin
 
 [Term]
 id: HANCESTRO:0524
 name: Motswana
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Botswana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Botswana ! isDemonymOf Botswana
 
 [Term]
 id: HANCESTRO:0525
 name: Burkinabe
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Burkina:Faso {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burkina Faso
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Burkina:Faso ! isDemonymOf Burkina Faso
 
 [Term]
 id: HANCESTRO:0526
 name: Burundian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Burundi
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Burundi ! isDemonymOf Burundi
 
 [Term]
 id: HANCESTRO:0527
 name: Central African
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Central African Republic
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Central_African_Republic ! isDemonymOf Central African Republic
 
 [Term]
 id: HANCESTRO:0528
 name: Comoran
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Comoros
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Comoros ! isDemonymOf Comoros
 
 [Term]
 id: HANCESTRO:0529
 name: Congolese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Democratic Republic of the Congo
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Republic of the Congo
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Democratic_Republic_of_the_Congo ! isDemonymOf Democratic Republic of the Congo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Republic_of_the_Congo ! isDemonymOf Republic of the Congo
 
 [Term]
 id: HANCESTRO:0530
 name: Ivoirian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Ivory:Coast {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Côte d'Ivoire
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Ivory:Coast ! isDemonymOf Côte d'Ivoire
 
 [Term]
 id: HANCESTRO:0531
 name: Djiboutian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Djibouti
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Djibouti ! isDemonymOf Djibouti
 
 [Term]
 id: HANCESTRO:0532
 name: Equatorial Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Equatorial:Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Equatorial Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Equatorial:Guinea ! isDemonymOf Equatorial Guinea
 
 [Term]
 id: HANCESTRO:0533
 name: Eritrean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Eritrea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Eritrea ! isDemonymOf Eritrea
 
 [Term]
 id: HANCESTRO:0534
 name: Gabonese
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Gabon
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Gabon ! isDemonymOf Gabon
 
 [Term]
 id: HANCESTRO:0535
 name: Gambian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 The:Gambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf The Gambia
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 The:Gambia ! isDemonymOf The Gambia
 
 [Term]
 id: HANCESTRO:0536
 name: Ghanaian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Ghana
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Ghana ! isDemonymOf Ghana
 
 [Term]
 id: HANCESTRO:0537
 name: Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Guinea ! isDemonymOf Guinea
 
 [Term]
 id: HANCESTRO:0538
 name: Bissau-Guinean
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 Guinea:Bissau {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Guinea-Bissau
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 Guinea:Bissau ! isDemonymOf Guinea-Bissau
 
 [Term]
 id: HANCESTRO:0539
 name: Mosotho
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Lesotho
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Lesotho ! isDemonymOf Lesotho
 
 [Term]
 id: HANCESTRO:0540
 name: Malawian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Malawi
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Malawi ! isDemonymOf Malawi
 
 [Term]
 id: HANCESTRO:0541
 name: Malian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mali
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mali ! isDemonymOf Mali
 
 [Term]
 id: HANCESTRO:0542
 name: Mozambican
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Mozambique
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Mozambique ! isDemonymOf Mozambique
 
 [Term]
 id: HANCESTRO:0543
 name: Nigerien
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Niger
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Niger ! isDemonymOf Niger
 
 [Term]
 id: HANCESTRO:0544
 name: Nigerian
-is_a: HANCESTRO:0011 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Nigeria
+is_a: HANCESTRO:0011 ! Sub-Saharan African
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Nigeria ! isDemonymOf Nigeria
 
 [Term]
 id: HANCESTRO:0545
 name: Rwandan
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Rwanda
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Rwanda ! isDemonymOf Rwanda
 
 [Term]
 id: HANCESTRO:0546
 name: Swazi
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Swaziland
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Swaziland ! isDemonymOf Swaziland
 
 [Term]
 id: HANCESTRO:0547
 name: Togolese
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Togo
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Togo ! isDemonymOf Togo
 
 [Term]
 id: HANCESTRO:0548
 name: Tanzanian
 is_a: HANCESTRO:0011 ! Sub-Saharan African
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Tanzania
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Tanzania ! isDemonymOf Tanzania
 
 [Term]
 id: HANCESTRO:0549
 name: Zambian
 is_a: HANCESTRO:0566 ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zambia
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zambia ! isDemonymOf Zambia
 
 [Term]
 id: HANCESTRO:0550
 name: Zimbabweian
-is_a: HANCESTRO:0566 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! undefined ancestry population
-relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! isDemonymOf Zimbabwe
+is_a: HANCESTRO:0566 ! undefined ancestry population
+relationship: HANCESTRO:0330 http://dbpedia.org/resource/Zimbabwe ! isDemonymOf Zimbabwe
 
 [Term]
 id: HANCESTRO:0551
@@ -2621,67 +2503,99 @@ property_value: IAO:0000119 "PMID:31626772" xsd:string
 id: Holy:See
 name: Holy See
 xref: GAZ:00003103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: Hong:Kong
 name: Hong Kong
 synonym: "China, Hong Kong SAR" EXACT []
 xref: GAZ:00003203
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: Ivory:Coast
 name: Côte d'Ivoire
 synonym: "Ivory Coast" EXACT []
 xref: GAZ:00000906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Marshall:Islands
 name: Marshall Islands
 xref: GAZ:00007161
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
+
+[Term]
+id: Middle:Africa
+name: Middle Africa
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: NCIT:C25464
+name: Country
+def: "A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states." []
+is_a: COB:0000032 ! geographical location
+relationship: RO:0001025 HANCESTRO:0002 {all_only="true"} ! located in region
 
 [Term]
 id: Netherlands:Antilles
 name: Netherlands Antilles
 xref: GAZ:00004019
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: New:Caledonia
 name: New Caledonia
 xref: GAZ:00005206
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: New:Zealand
 name: New Zealand
 xref: GAZ:00000469
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: Norfolk:Island
 name: Norfolk Island
 xref: GAZ:00005913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: North:Korea
 name: North Korea
 synonym: "Democratic People's Republic of Korea" EXACT []
 xref: GAZ:00002801
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
+
+[Term]
+id: Northern:Africa
+name: Northern Africa
+xref: GAZ:00000555
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Northern:America
+name: Northern America
+xref: GAZ:00000458
+is_a: GAZ:00000013 ! continent
+
+[Term]
+id: Northern:Europe
+name: Northern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: OBI:0000181
@@ -2716,24 +2630,24 @@ id: Palestinian:territories
 name: Palestinian Territories
 synonym: "Occupied Palestinian Territory" EXACT []
 xref: GAZ:00002475
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Pitcairn:Islands
 name: Pitcairn Islands
 synonym: "Pitcairn, Henderson, Ducie and Oeno Islands" EXACT []
 xref: GAZ:00005867
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 property_value: IAO:0000118 "Pitcairn" xsd:string
 
 [Term]
 id: Puerto:Rico
 name: Puerto Rico
 xref: GAZ:00006935
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 property_value: IAO:0000118 "Commonwealth of Puerto Rico" xsd:string
 
 [Term]
@@ -2746,1487 +2660,1611 @@ id: Saint:Helena
 name: Saint Helena
 synonym: "St. Helena" EXACT []
 xref: GAZ:00000849
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Saint:Lucia
 name: Saint Lucia
 xref: GAZ:00006909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: Saint:Martin
 name: Saint Martin
 xref: GAZ:00005841
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: San:Marino
 name: San Marino
 xref: GAZ:00003102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: Saudi:Arabia
 name: Saudi Arabia
 xref: GAZ:00005279
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: Sierra:Leone
 name: Sierra Leone
 xref: GAZ:00000914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: Sint:Maarten
 name: Sint Maarten
 xref: GAZ:00012579
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: Solomon:Islands
 name: Solomon Islands
 xref: GAZ:00005275
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
+
+[Term]
+id: South-Eastern:Asia
+name: South-Eastern Asia
+xref: GAZ:00000559
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: South-central:Asia
+name: South-Central Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Africa
 name: South Africa
 xref: GAZ:00000553
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
+
+[Term]
+id: South:Asia
+name: South Asia
+xref: GAZ:00002472
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
 
 [Term]
 id: South:Korea
 name: South Korea
 synonym: "Republic of Korea" EXACT []
 xref: GAZ:00002802
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: South:Sudan
 name: South Sudan
 xref: GAZ:00233439
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
+
+[Term]
+id: Southern:Africa
+name: Southern Africa
+xref: GAZ:00000553
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Southern:Europe
+name: Southern Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Sri:Lanka
 name: Sri Lanka
 xref: GAZ:00003924
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: The:Bahamas
 name: The Bahamas
 synonym: "Bahamas" EXACT []
 xref: GAZ:00002733
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: The:Gambia
 name: The Gambia
 synonym: "Gambia" EXACT []
 xref: GAZ:00000907
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: United:Kingdom
 name: United Kingdom
 synonym: "U.K." EXACT []
 xref: GAZ:00002637
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: United:States
 name: United States
 synonym: "United States of America" EXACT []
 xref: GAZ:00002459
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 property_value: IAO:0000118 "U.S." xsd:string
+
+[Term]
+id: Western:Africa
+name: Western Africa
+xref: GAZ:00000554
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Africa {all_only="true"} ! part_of Africa
+
+[Term]
+id: Western:Asia
+name: Western Asia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Asia {all_only="true"} ! part_of Asia
+
+[Term]
+id: Western:Europe
+name: Western Europe
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: Western:Sahara
 name: Western Sahara
 xref: GAZ:00000564
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Afghanistan
 name: Afghanistan
 xref: GAZ:00006882
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
+
+[Term]
+id: http://dbpedia.org/resource/Africa
+name: Africa
+xref: GAZ:00000457
+is_a: GAZ:00000013 ! continent
+disjoint_from: http://dbpedia.org/resource/Asia ! Asia
 
 [Term]
 id: http://dbpedia.org/resource/Albania
 name: Albania
 xref: GAZ:00002953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Algeria
 name: Algeria
 xref: GAZ:00000563
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Andorra
 name: Andorra
 xref: GAZ:00002948
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Angola
 name: Angola
 xref: GAZ:00001095
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Anguilla
 name: Anguilla
 xref: GAZ:00009159
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Antigua_and_Barbuda
 name: Antigua and Barbuda
 xref: GAZ:00006883
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Argentina
 name: Argentina
 xref: GAZ:00002928
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Armenia
 name: Armenia
 xref: GAZ:00004094
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Aruba
 name: Aruba
 xref: GAZ:00004025
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
+
+[Term]
+id: http://dbpedia.org/resource/Asia
+name: Asia
+xref: GAZ:00000465
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Australia
 name: Australia
 xref: GAZ:00000463
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0051 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Australia/New Zealand
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Austria
 name: Austria
 xref: GAZ:00002942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Azerbaijan
 name: Azerbaijan
 xref: GAZ:00004941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bahrain
 name: Bahrain
 xref: GAZ:00005281
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bangladesh
 name: Bangladesh
 xref: GAZ:00003750
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Barbados
 name: Barbados
 xref: GAZ:00001251
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Belarus
 name: Belarus
 xref: GAZ:00006886
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belgium
 name: Belgium
 xref: GAZ:00002938
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Belize
 name: Belize
 xref: GAZ:00002934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Benin
 name: Benin
 xref: GAZ:00000904
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Bermuda
 name: Bermuda
 xref: GAZ:00001264
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Bhutan
 name: Bhutan
 xref: GAZ:00003920
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bolivia
 name: Bolivia
 xref: GAZ:00002511
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Bosnia_and_Herzegovina
 name: Bosnia and Herzegovina
 xref: GAZ:00006887
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Botswana
 name: Botswana
 xref: GAZ:00001097
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Brazil
 name: Brazil
 xref: GAZ:00002828
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/British_Virgin_Islands
 name: British Virgin Islands
 xref: GAZ:00003961
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Brunei
 name: Brunei
 synonym: "Brunei Darussalam" EXACT []
 xref: GAZ:00003901
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Bulgaria
 name: Bulgaria
 xref: GAZ:00002950
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Burundi
 name: Burundi
 xref: GAZ:00001090
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Cambodia
 name: Cambodia
 xref: GAZ:00006888
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cameroon
 name: Cameroon
 xref: GAZ:00001093
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Canada
 name: Canada
 xref: GAZ:00002560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
+
+[Term]
+id: http://dbpedia.org/resource/Caribbean
+name: Caribbean
+is_a: HANCESTRO:0002 ! region
+disjoint_from: Central:America ! Central America
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Central_African_Republic
 name: Central African Republic
 xref: GAZ:00001089
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chad
 name: Chad
 xref: GAZ:00000586
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Chile
 name: Chile
 xref: GAZ:00002825
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/China
 name: China
 xref: GAZ:00002845
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Cocos_(Keeling)_Islands
 name: Cocos (Keeling) Islands
 xref: GAZ:00009721
-is_a: HANCESTRO:0003 ! country
+is_a: NCIT:C25464 ! Country
 relationship: RO:0001025 HANCESTRO:0051 {all_only="true"} ! located in Australia/New Zealand
 
 [Term]
 id: http://dbpedia.org/resource/Colombia
 name: Colombia
 xref: GAZ:00002929
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Comoros
 name: Comoros
 xref: GAZ:00005820
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Croatia
 name: Croatia
 xref: GAZ:00002719
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Cuba
 name: Cuba
 xref: GAZ:00003762
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Curacao
 name: Curacao
 xref: GAZ:00012582
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Cyprus
 name: Cyprus
 xref: GAZ:00453362
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Democratic_Republic_of_the_Congo
 name: Democratic Republic of the Congo
 xref: GAZ:00001086
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Denmark
 name: Denmark
 xref: GAZ:00002635
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Djibouti
 name: Djibouti
 xref: GAZ:00000582
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Dominica
 name: Dominica
 xref: GAZ:00006890
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Ecuador
 name: Ecuador
 xref: GAZ:00002912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Egypt
 name: Egypt
 xref: GAZ:00003934
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Eritrea
 name: Eritrea
 xref: GAZ:00000581
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Estonia
 name: Estonia
 xref: GAZ:00002959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ethiopia
 name: Ethiopia
 xref: GAZ:00000567
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Europe
+name: Europe
+xref: GAZ:00000464
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Federated_States_of_Micronesia
 name: Micronesia (Federated States of)
 xref: GAZ:00006897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Fiji
 name: Fiji
 xref: GAZ:00006891
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Finland
 name: Finland
 xref: GAZ:00002937
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/France
 name: France
 xref: GAZ:00002940
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Gabon
 name: Gabon
 xref: GAZ:00001092
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Germany
 name: Germany
 xref: GAZ:00002646
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Ghana
 name: Ghana
 xref: GAZ:00000908
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Gibraltar
 name: Gibraltar
 xref: GAZ:00003987
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greece
 name: Greece
 xref: GAZ:00002945
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Greenland
 name: Greenland
 xref: GAZ:00001507
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Grenada
 name: Grenada
 xref: GAZ:02000573
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guadeloupe
 name: Guadeloupe
 xref: GAZ:00067135
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Guam
 name: Guam
 xref: GAZ:00006933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Guatemala
 name: Guatemala
 xref: GAZ:00002936
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Guinea
 name: Guinea
 xref: GAZ:00000909
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Guyana
 name: Guyana
 xref: GAZ:00002522
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Haiti
 name: Haiti
 xref: GAZ:00003953
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Honduras
 name: Honduras
 xref: GAZ:00002894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Hungary
 name: Hungary
 xref: GAZ:00002952
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Iceland
 name: Iceland
 xref: GAZ:00000843
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/India
 name: India
 xref: GAZ:00002839
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Indonesia
 name: Indonesia
 xref: GAZ:00003727
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iran
 name: Iran
 synonym: "Iran (Islamic Republic of)" EXACT []
 xref: GAZ:00004474
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Iraq
 name: Iraq
 xref: GAZ:00004483
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Isle_of_Man
 name: Isle of Man
 xref: GAZ:00052477
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Israel
 name: Israel
 xref: GAZ:00002476
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Italy
 name: Italy
 xref: GAZ:00002650
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Jamaica
 name: Jamaica
 xref: GAZ:00003781
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Japan
 name: Japan
 xref: GAZ:00002747
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Jordan
 name: Jordan
 xref: GAZ:00002473
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kazakhstan
 name: Kazakhstan
 xref: GAZ:00004999
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kenya
 name: Kenya
 xref: GAZ:00001101
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Kiribati
 name: Kiribati
 xref: GAZ:00006894
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Kosovo
 name: Kosovo
 xref: GAZ:00011337
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Kuwait
 name: Kuwait
 xref: GAZ:00005285
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Kyrgyzstan
 name: Kyrgyzstan
 xref: GAZ:00006893
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Laos
 name: Laos
 synonym: "Lao People's Democratic Republic" EXACT []
 xref: GAZ:00006889
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
+
+[Term]
+id: http://dbpedia.org/resource/Latin_America_and_the_Caribbean
+name: Latin America and the Caribbean
+xref: GAZ:00000459
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Latvia
 name: Latvia
 xref: GAZ:00002958
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lebanon
 name: Lebanon
 xref: GAZ:00002478
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Lesotho
 name: Lesotho
 xref: GAZ:00001098
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liberia
 name: Liberia
 xref: GAZ:00000911
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Libya
 name: Libya
 synonym: "Libyan Arab Jamahiriya" EXACT []
 xref: GAZ:00000566
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Liechtenstein
 name: Liechtenstein
 xref: GAZ:00003858
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Lithuania
 name: Lithuania
 xref: GAZ:00002960
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Luxembourg
 name: Luxembourg
 xref: GAZ:00002947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Macau
 name: Macau
 synonym: "China, Macao SAR" EXACT []
 xref: GAZ:00003202
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Madagascar
 name: Madagascar
 xref: GAZ:00001108
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malawi
 name: Malawi
 xref: GAZ:00001105
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malaysia
 name: Malaysia
 xref: GAZ:00003902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Maldives
 name: Maldives
 xref: GAZ:00006896
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Mali
 name: Mali
 xref: GAZ:00000584
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Malta
 name: Malta
 xref: GAZ:00004017
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Martinique
 name: Martinique
 xref: GAZ:00003947
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Mauretania
 name: Mauritania
 synonym: "Mauretania" EXACT []
 xref: GAZ:00000583
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mauritius
 name: Mauritius
 xref: GAZ:00003745
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mayotte
 name: Mayotte
 xref: GAZ:00003943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/Melanesia
+name: Melanesia
+xref: GAZ:00005860
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Mexico
 name: Mexico
 xref: GAZ:00002852
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
+
+[Term]
+id: http://dbpedia.org/resource/Micronesia
+name: Micronesia
+xref: GAZ:00005862
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Moldova
 name: Moldova
 synonym: "Republic of Moldova" EXACT []
 xref: GAZ:00003897
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Monaco
 name: Monaco
 xref: GAZ:00003857
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Mongolia
 name: Mongolia
 xref: GAZ:00008744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Montenegro
 name: Montenegro
 xref: GAZ:00006898
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Montserrat
 name: Montserrat
 xref: GAZ:00003988
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Morocco
 name: Morocco
 xref: GAZ:00000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Mozambique
 name: Mozambique
 xref: GAZ:00001100
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Myanmar
 name: Myanmar
 synonym: "Burma" EXACT []
 xref: GAZ:00006899
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Namibia
 name: Namibia
 xref: GAZ:00001096
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nauru
 name: Nauru
 xref: GAZ:00006900
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Nepal
 name: Nepal
 xref: GAZ:00004399
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Netherlands
 name: Netherlands
 xref: GAZ:00001549
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Nicaragua
 name: Nicaragua
 xref: GAZ:00002978
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Niger
 name: Niger
 xref: GAZ:00000585
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Nigeria
 name: Nigeria
 xref: GAZ:00000912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Niue
 name: Niue
 xref: GAZ:00006902
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 property_value: IAO:0000118 "Niue Fekai" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Northern_Mariana_Islands
 name: Northern Mariana Islands
 xref: GAZ:00003958
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Norway
 name: Norway
 xref: GAZ:00002699
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 property_value: IAO:0000118 "Kingdom of Norway" xsd:string
+
+[Term]
+id: http://dbpedia.org/resource/Oceania
+name: Oceania
+xref: GAZ:00000468
+is_a: GAZ:00000013 ! continent
 
 [Term]
 id: http://dbpedia.org/resource/Oman
 name: Oman
 xref: GAZ:00005283
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Pakistan
 name: Pakistan
 xref: GAZ:00005246
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Palau
 name: Palau
 xref: GAZ:00006905
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0053 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Micronesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Micronesia {all_only="true"} ! located in Micronesia
 
 [Term]
 id: http://dbpedia.org/resource/Panama
 name: Panama
 xref: GAZ:00002892
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0050 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Central America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Central:America {all_only="true"} ! located in Central America
 
 [Term]
 id: http://dbpedia.org/resource/Papua_New_Guinea
 name: Papua New Guinea
 xref: GAZ:00003922
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Paraguay
 name: Paraguay
 xref: GAZ:00002933
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Peru
 name: Peru
 xref: GAZ:00002932
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Philippines
 name: Philippines
 xref: GAZ:00004525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 property_value: IAO:0000118 "The Philippines" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Poland
 name: Poland
 xref: GAZ:00002939
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
+
+[Term]
+id: http://dbpedia.org/resource/Polynesia
+name: Polynesia
+xref: GAZ:00005861
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Oceania {all_only="true"} ! part_of Oceania
 
 [Term]
 id: http://dbpedia.org/resource/Portugal
 name: Portugal
 xref: GAZ:00002944
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 property_value: IAO:0000118 "Portugese Republic" xsd:string
 
 [Term]
 id: http://dbpedia.org/resource/Qatar
 name: Qatar
 xref: GAZ:00005286
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Ireland
 name: Republic of Ireland
 synonym: "Ireland" EXACT []
 xref: GAZ:00002943
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_Macedonia
 name: Republic of Macedonia
 synonym: "The former Yugoslav Republic of Macedonia" EXACT []
 xref: GAZ:00006895
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Republic_of_the_Congo
 name: Republic of the Congo
 synonym: "Congo" EXACT []
 xref: GAZ:00001088
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Romania
 name: Romania
 xref: GAZ:00002951
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Russia
 name: Russia
 synonym: "Russian Federation" EXACT []
 xref: GAZ:00002721
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Rwanda
 name: Rwanda
 xref: GAZ:00001087
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Réunion
 name: Réunion
 xref: GAZ:00053746
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Kitts_and_Nevis
 name: Saint Kitts and Nevis
 xref: GAZ:00006906
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Pierre_and_Miquelon
 name: Saint Pierre and Miquelon
 synonym: "Saint-Pierre-et-Miquelon" EXACT []
 xref: GAZ:00003942
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
+is_a: NCIT:C25464 ! Country
 
 [Term]
 id: http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines
 name: Saint Vincent and the Grenadines
 xref: GAZ:02000565
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Samoa
 name: Samoa
 xref: GAZ:00006910
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
+
+[Term]
+id: http://dbpedia.org/resource/Scandinavia
+name: Scandinavia
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Europe {all_only="true"} ! part_of Europe
 
 [Term]
 id: http://dbpedia.org/resource/Scotland
 name: Scotland
 xref: GAZ:00002639
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Senegal
 name: Senegal
 xref: GAZ:00000913
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Serbia
 name: Serbia
 xref: GAZ:00002957
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Seychelles
 name: Seychelles
 xref: GAZ:00005821
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Singapore
 name: Singapore
 xref: GAZ:00003923
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Slovakia
 name: Slovakia
 xref: GAZ:00002956
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Slovenia
 name: Slovenia
 xref: GAZ:00002955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Somalia
 name: Somalia
 xref: GAZ:00001104
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
+
+[Term]
+id: http://dbpedia.org/resource/SouthAmerica
+name: South America
+xref: GAZ:00000459
+is_a: HANCESTRO:0002 ! region
+relationship: BFO:0000050 http://dbpedia.org/resource/Latin_America_and_the_Caribbean {all_only="true"} ! part_of Latin America and the Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Spain
 name: Spain
 xref: GAZ:00000591
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0046 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Europe {all_only="true"} ! located in Southern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Sudan
 name: Sudan
 xref: GAZ:00000560
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Suriname
 name: Suriname
 xref: GAZ:00002525
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Swaziland
 name: Swaziland
 xref: GAZ:00001099
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0038 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Southern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Southern:Africa {all_only="true"} ! located in Southern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Sweden
 name: Sweden
 xref: GAZ:00002729
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: BFO:0000050 HANCESTRO:0288 {all_only="true"} ! part_of Scandinavia
-relationship: RO:0001025 HANCESTRO:0045 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Europe
+is_a: NCIT:C25464 ! Country
+relationship: BFO:0000050 http://dbpedia.org/resource/Scandinavia {all_only="true"} ! part_of Scandinavia
+relationship: RO:0001025 Northern:Europe {all_only="true"} ! located in Northern Europe
 
 [Term]
 id: http://dbpedia.org/resource/Switzerland
 name: Switzerland
 xref: GAZ:00002941
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0047 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Europe {all_only="true"} ! located in Western Europe
 
 [Term]
 id: http://dbpedia.org/resource/Syria
 name: Syria
 xref: GAZ:00002474
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/São_Tomé_and_Príncipe
 name: São Tomé and Príncipe
 xref: GAZ:00006927
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0036 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Middle Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Middle:Africa {all_only="true"} ! located in Middle Africa
 
 [Term]
 id: http://dbpedia.org/resource/Taiwan
 name: Taiwan
 xref: GAZ:00005341
-is_a: HANCESTRO:0003 ! country
-relationship: RO:0001025 HANCESTRO:0055 {all_only="true"} ! located in Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Asia {all_only="true"} ! located in Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tajikistan
 name: Tajikistan
 xref: GAZ:00006912
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Tanzania
 name: Tanzania
 synonym: "United Republic of Tanzania" EXACT []
 xref: GAZ:00001103
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Thailand
 name: Thailand
 xref: GAZ:00003744
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Togo
 name: Togo
 xref: GAZ:00000915
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0039 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Africa {all_only="true"} ! located in Western Africa
 
 [Term]
 id: http://dbpedia.org/resource/Tokelau
 name: Tokelau
 xref: GAZ:00006914
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Tonga
 name: Tonga
 xref: GAZ:00006916
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Trinidad_and_Tobago
 name: Trinidad and Tobago
 xref: GAZ:00003767
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tunisia
 name: Tunisia
 xref: GAZ:00000562
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0037 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Northern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Northern:Africa {all_only="true"} ! located in Northern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Turkey
 name: Turkey
 xref: GAZ:00000558
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turkmenistan
 name: Turkmenistan
 xref: GAZ:00005018
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Turks_and_Caicos_Islands
 name: Turks and Caicos Islands
 xref: GAZ:00003955
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Tuvalu
 name: Tuvalu
 xref: GAZ:00009715
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Uganda
 name: Uganda
 xref: GAZ:00001102
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Ukraine
 name: Ukraine
 xref: GAZ:00002724
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0044 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Europe
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Europe {all_only="true"} ! located in Eastern Europe
 
 [Term]
 id: http://dbpedia.org/resource/United_Arab_Emirates
 name: United Arab Emirates
 xref: GAZ:00005282
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/United_States_Virgin_Islands
 name: United States Virgin Islands
 synonym: "U.S. Virgin Islands" EXACT []
 xref: GAZ:00003959
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0048 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Caribbean
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Caribbean {all_only="true"} ! located in Caribbean
 
 [Term]
 id: http://dbpedia.org/resource/Uruguay
 name: Uruguay
 xref: GAZ:00002930
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Uzbekistan
 name: Uzbekistan
 xref: GAZ:00004979
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0041 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Central Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-central:Asia {all_only="true"} ! located in South-Central Asia
 
 [Term]
 id: http://dbpedia.org/resource/Vanuatu
 name: Vanuatu
 xref: GAZ:00006918
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0052 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Melanesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Melanesia {all_only="true"} ! located in Melanesia
 
 [Term]
 id: http://dbpedia.org/resource/Venezuela
 name: Venezuela
 xref: GAZ:00002931
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0049 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South America
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/SouthAmerica {all_only="true"} ! located in South America
 
 [Term]
 id: http://dbpedia.org/resource/Vietnam
 name: Vietnam
 xref: GAZ:00003756
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0042 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in South-Eastern Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 South-Eastern:Asia {all_only="true"} ! located in South-Eastern Asia
 
 [Term]
 id: http://dbpedia.org/resource/Wallis_and_Futuna
 name: Wallis and Futuna
 synonym: "Wallis and Futuna Islands" EXACT []
 xref: GAZ:00007191
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0054 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Polynesia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 http://dbpedia.org/resource/Polynesia {all_only="true"} ! located in Polynesia
 
 [Term]
 id: http://dbpedia.org/resource/Yemen
 name: Yemen
 xref: GAZ:00005284
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0043 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Western Asia
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Western:Asia {all_only="true"} ! located in Western Asia
 
 [Term]
 id: http://dbpedia.org/resource/Zambia
 name: Zambia
 xref: GAZ:00001107
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Term]
 id: http://dbpedia.org/resource/Zimbabwe
 name: Zimbabwe
 xref: GAZ:00001106
-is_a: HANCESTRO:0003 {http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! country
-relationship: RO:0001025 HANCESTRO:0035 {all_only="true", http://purl.org/dc/terms/contributor="http://e-lico.eu/populous#OPPL_pattern"} ! located in Eastern Africa
+is_a: NCIT:C25464 ! Country
+relationship: RO:0001025 Eastern:Africa {all_only="true"} ! located in Eastern Africa
 
 [Typedef]
 id: BFO:0000050

--- a/hancestro.owl
+++ b/hancestro.owl
@@ -18,13 +18,13 @@
      xmlns:subsets="http://purl.obolibrary.org/obo/ro/subsets#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hancestro.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2023-10-13/hancestro.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/hancestro.owl"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0004"/>
         <obo:IAO_0000700 rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0304"/>
         <dc:description>Human ancestry ontology for the NHGRI GWAS Catalog</dc:description>
         <dc:title>Human Ancestry Ontology</dc:title>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
-        <owl:versionInfo>2023-10-13</owl:versionInfo>
+        <owl:versionInfo>2024-01-24</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -66,7 +66,6 @@
         <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -93,19 +92,14 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label>definition</rdfs:label>
-        <rdfs:label xml:lang="en">definition</rdfs:label>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">editor note</rdfs:label>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
     
 
 
@@ -121,8 +115,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">alternative term</rdfs:label>
         <rdfs:label>alternative_term</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -131,8 +123,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
-        <rdfs:label xml:lang="en">definition source</rdfs:label>
         <rdfs:label>definition_source</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -658,12 +648,6 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/ro/subsets#ro-eco"/>
         <rdfs:label xml:lang="en">precedes</rdfs:label>
     </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000137 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000137"/>
     
 
 
@@ -2556,281 +2540,181 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Afghanistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Afghanistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid136"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006882</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Afghanistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid136">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid136"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
+        <rdfs:label>Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Albania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Albania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid139"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Albania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid139">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Albania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid139"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Algeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Algeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid142"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000563</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Algeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid142">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Algeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid142"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/American_Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/American_Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid145"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">American Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid145">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid145"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Andorra -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Andorra">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid148"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002948</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Andorra</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid148">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Andorra"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid148"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Angola -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Angola">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid151"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001095</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Angola</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid151">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Angola"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid151"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Anguilla -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Anguilla">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid154"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009159</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Anguilla</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid154">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid154"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Antigua_and_Barbuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Antigua_and_Barbuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid157"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006883</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Antigua and Barbuda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid157">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid157"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Argentina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Argentina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid160"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002928</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Argentina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid160">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Argentina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid160"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Armenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Armenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid163"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004094</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Armenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid163">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Armenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid163"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Aruba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Aruba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004025</oboInOwl:hasDbXref>
@@ -2839,826 +2723,536 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://dbpedia.org/resource/Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
+        <rdfs:label>Asia</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Australia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Australia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid167"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000463</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Australia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid167">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Australia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid167"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Austria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Austria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid170"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Austria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid170">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Austria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid170"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Azerbaijan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Azerbaijan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid173"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Azerbaijan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid173">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid173"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bahrain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bahrain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid176"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005281</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bahrain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid176">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid176"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bangladesh -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bangladesh">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid179"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003750</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bangladesh</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid179">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid179"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Barbados -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Barbados">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid182"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001251</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Barbados</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid182">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Barbados"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid182"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belarus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belarus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid185"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006886</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belarus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid185">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belarus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid185"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belgium -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belgium">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid188"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002938</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belgium</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid188">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belgium"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid188"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Belize -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Belize">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid191"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Belize</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid191">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Belize"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid191"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Benin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Benin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid194"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000904</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Benin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid194">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Benin"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid194"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bermuda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bermuda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001264</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bermuda</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bhutan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bhutan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid198"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003920</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bhutan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid198">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid198"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bolivia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bolivia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid201"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002511</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bolivia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid201">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid201"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bosnia_and_Herzegovina -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bosnia_and_Herzegovina">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid204"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006887</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bosnia and Herzegovina</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid204">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid204"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Botswana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Botswana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid207"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001097</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Botswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid207">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Botswana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid207"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brazil -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brazil">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid210"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002828</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Brazil</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid210">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brazil"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid210"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/British_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/British_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid213"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003961</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">British Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid213">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid213"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Brunei -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Brunei">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid216"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003901</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Brunei Darussalam</oboInOwl:hasExactSynonym>
         <rdfs:label>Brunei</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid216">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Brunei"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid216"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Bulgaria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Bulgaria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid219"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002950</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Bulgaria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid219">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid219"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burkina_Faso -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burkina_Faso">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid222"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burkina Faso</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid222">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid222"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Burundi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Burundi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid225"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001090</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Burundi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid225">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Burundi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid225"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cambodia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cambodia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid228"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006888</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cambodia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid228">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid228"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cameroon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cameroon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid231"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001093</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cameroon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid231">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid231"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Canada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Canada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00002560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Canada</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Canada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cape_Verde -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cape_Verde">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid235"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001227</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cape Verde</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid235">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid235"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Cayman_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cayman_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid238"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003986</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cayman Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid238">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid238"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Central_African_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Central_African_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001089</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Central African Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid241">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid241"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Central_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Central_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
+        <rdfs:label>Central America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Chad -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chad">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid244"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000586</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chad</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid244">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chad"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid244"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Channel_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Channel_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid247"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001539</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Channel Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid247">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid247"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Chile -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Chile">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid250"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002825</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Chile</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid250">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Chile"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid250"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/China -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/China">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid253"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002845</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">China</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid253">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/China"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid253"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Christmas_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Christmas_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -3674,173 +3268,107 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Colombia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Colombia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid257"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002929</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Colombia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid257">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Colombia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid257"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Comoros -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Comoros">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid260"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005820</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Comoros</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid260">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Comoros"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid260"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cook_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cook_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid263"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053798</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cook Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid263">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid263"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Costa_Rica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Costa_Rica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid266"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002901</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Costa Rica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid266">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid266"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Croatia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Croatia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid269"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002719</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Croatia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid269">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Croatia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid269"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cuba -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cuba">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid272"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003762</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cuba</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid272">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cuba"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid272"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Curacao -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Curacao">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012582</oboInOwl:hasDbXref>
@@ -3852,179 +3380,113 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Cyprus -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cyprus">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid276"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00453362</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Cyprus</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid276">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid276"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Czech_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Czech_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid279"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002954</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Czech Republic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid279">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid279"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Democratic_Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid282"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001086</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Democratic Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid282">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid282"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Denmark -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Denmark">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid286"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002635</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Denmark</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid286">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Denmark"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid286"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Djibouti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Djibouti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid289"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000582</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Djibouti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid289">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid289"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid292"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006890</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Dominica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid292">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Dominica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid292"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Dominican_Republic -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Dominican_Republic">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003952</oboInOwl:hasDbXref>
@@ -4036,1329 +3498,852 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/East_Timor -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/East_Timor">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid296"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006913</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Timor-Leste</oboInOwl:hasExactSynonym>
         <rdfs:label>East Timor</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid296">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid296"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
+        <rdfs:label>Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Eastern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Eastern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Eastern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Ecuador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ecuador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid299"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ecuador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid299">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid299"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Egypt -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Egypt">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid302"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003934</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Egypt</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid302">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Egypt"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid302"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/El_Salvador -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/El_Salvador">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid305"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">El Salvador</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid305">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid305"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Equatorial_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Equatorial_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001091</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Equatorial Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid308">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid308"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Eritrea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Eritrea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid311"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000581</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Eritrea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid311">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid311"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Estonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Estonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002959</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Estonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid314">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Estonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid314"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ethiopia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ethiopia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid317"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000567</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ethiopia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid317">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid317"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
+        <rdfs:label>Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Faeroe_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Faeroe_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid320"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Faroe Islands</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00059206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Faeroe Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid320">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid320"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Falkland_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Falkland_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid323"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001412</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Falkland Islands (Malvinas)</oboInOwl:hasExactSynonym>
         <rdfs:label>Falkland Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid323">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid323"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Federated_States_of_Micronesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Federated_States_of_Micronesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid326"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006897</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Micronesia (Federated States of)</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid326">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid326"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Fiji -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Fiji">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid329"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006891</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Fiji</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid329">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Fiji"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid329"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Finland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Finland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid332"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002937</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Finland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid332">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Finland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid332"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/France -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/France">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid335"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002940</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">France</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid335">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/France"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid335"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Guiana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Guiana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid338"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002516</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Guiana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid338">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid338"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/French_Polynesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/French_Polynesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid341"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">French Polynesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid341">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid341"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gabon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gabon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid344"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001092</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gabon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid344">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gabon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid344"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Germany -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Germany">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002646</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Germany</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid347">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Germany"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid347"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ghana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ghana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid350"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000908</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ghana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid350">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ghana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid350"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Gibraltar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Gibraltar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid353"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003987</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Gibraltar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid353">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid353"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greece -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greece">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid356"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002945</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greece</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid356">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greece"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid356"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Greenland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Greenland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00001507</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Greenland</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Greenland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Grenada -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Grenada">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid360"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000573</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Grenada</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid360">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Grenada"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid360"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guadeloupe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guadeloupe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid363"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00067135</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guadeloupe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid363">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guadeloupe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid363"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid366"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid366">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid366"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guatemala -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guatemala">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid369"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002936</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guatemala</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid369">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid369"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid372"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid372">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid372"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guinea_Bissau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guinea_Bissau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid375"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guinea-Bissau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid375">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid375"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Guyana -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Guyana">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid378"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002522</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Guyana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid378">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Guyana"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid378"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Haiti -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Haiti">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid381"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003953</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Haiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid381">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Haiti"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid381"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Holy_See -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Holy_See">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid384"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003103</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Holy See</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid384">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Holy_See"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid384"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Honduras -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Honduras">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid387"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Honduras</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid387">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Honduras"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid387"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hong_Kong -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hong_Kong">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid390"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003203</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Hong Kong SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Hong Kong</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid390">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hong_Kong"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid390"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Hungary -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Hungary">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid393"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002952</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Hungary</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid393">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Hungary"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid393"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iceland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iceland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid396"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000843</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iceland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid396">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iceland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid396"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/India -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/India">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid399"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002839</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">India</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid399">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/India"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid399"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Indonesia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Indonesia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid402"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003727</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Indonesia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid402">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid402"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iran -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iran">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid405"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004474</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Iran (Islamic Republic of)</oboInOwl:hasExactSynonym>
         <rdfs:label>Iran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid405">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iran"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid405"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Iraq -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Iraq">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid408"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004483</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Iraq</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid408">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Iraq"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid408"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Isle_of_Man -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Isle_of_Man">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid411"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00052477</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Isle of Man</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid411">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid411"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Israel -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Israel">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid414"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002476</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Israel</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid414">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Israel"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid414"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Italy -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Italy">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid417"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002650</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Italy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid417">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Italy"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid417"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ivory_Coast -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ivory_Coast">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid420"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000906</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ivory Coast</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Côte d&apos;Ivoire</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid420">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid420"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jamaica -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jamaica">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid423"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003781</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jamaica</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid423">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid423"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Japan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Japan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid426"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002747</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Japan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid426">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Japan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid426"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Jordan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Jordan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid429"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002473</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Jordan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid429">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Jordan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid429"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kazakhstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kazakhstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid432"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004999</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kazakhstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid432">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid432"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kenya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kenya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid435"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001101</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kenya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid435">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kenya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid435"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kiribati -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kiribati">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid438"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006894</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid438">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid438"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kosovo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kosovo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00011337</oboInOwl:hasDbXref>
@@ -5370,1234 +4355,837 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Kuwait -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kuwait">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid442"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005285</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kuwait</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid442">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid442"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Kyrgyzstan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Kyrgyzstan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid445"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006893</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Kyrgyzstan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid445">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid445"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Laos -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Laos">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006889</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Lao People&apos;s Democratic Republic</oboInOwl:hasExactSynonym>
         <rdfs:label>Laos</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid448">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Laos"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid448"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Latin_America_and_the_Caribbean -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Latvia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Latvia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid451"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002958</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Latvia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid451">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Latvia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid451"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lebanon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lebanon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid454"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002478</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lebanon</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid454">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid454"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lesotho -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lesotho">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid457"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001098</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lesotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid457">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid457"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liberia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liberia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid460"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000911</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liberia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid460">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liberia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid460"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Libya -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Libya">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid463"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000566</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Libyan Arab Jamahiriya</oboInOwl:hasExactSynonym>
         <rdfs:label>Libya</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid463">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Libya"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid463"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Liechtenstein -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Liechtenstein">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid466"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003858</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Liechtenstein</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid466">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid466"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Lithuania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Lithuania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid469"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002960</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Lithuania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid469">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid469"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Luxembourg -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Luxembourg">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid472"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Luxembourg</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid472">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid472"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Macau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Macau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid475"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003202</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">China, Macao SAR</oboInOwl:hasExactSynonym>
         <rdfs:label>Macau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid475">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Macau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid475"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Madagascar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Madagascar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001108</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Madagascar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid478">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid478"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malawi -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malawi">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid481"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001105</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid481">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malawi"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid481"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malaysia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malaysia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid484"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malaysia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid484">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid484"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Maldives -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Maldives">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid487"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006896</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Maldives</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid487">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Maldives"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid487"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mali -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mali">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid490"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000584</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid490">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mali"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid490"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Malta -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Malta">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid493"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004017</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Malta</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid493">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Malta"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid493"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Marshall_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Marshall_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid496"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007161</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Marshall Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid496">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid496"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Martinique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Martinique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid499"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003947</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Martinique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid499">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Martinique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid499"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauretania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauretania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid502"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000583</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Mauretania</oboInOwl:hasExactSynonym>
         <rdfs:label>Mauritania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid502">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid502"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mauritius -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mauritius">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid505"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003745</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mauritius</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid505">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid505"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mayotte -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mayotte">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid508"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003943</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mayotte</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid508">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid508"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Melanesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Melanesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
+        <rdfs:label>Melanesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Mexico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mexico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid511"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002852</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mexico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid511">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mexico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid511"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Micronesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Micronesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
+        <rdfs:label>Micronesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Middle_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Middle_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Middle Africa</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Moldova -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Moldova">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid514"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003897</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Moldova</oboInOwl:hasExactSynonym>
         <rdfs:label>Moldova</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid514">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Moldova"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid514"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Monaco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Monaco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid517"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003857</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Monaco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid517">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Monaco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid517"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mongolia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mongolia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid520"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00008744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mongolia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid520">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mongolia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid520"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montenegro -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montenegro">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid523"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006898</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montenegro</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid523">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid523"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Montserrat -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Montserrat">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid526"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003988</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Montserrat</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid526">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid526"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Morocco -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Morocco">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid529"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Morocco</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid529">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Morocco"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid529"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Mozambique -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Mozambique">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001100</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Mozambique</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid532">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid532"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Myanmar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Myanmar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid535"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006899</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Burma</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Myanmar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid535">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid535"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Namibia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Namibia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid538"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001096</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Namibia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid538">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Namibia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid538"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nauru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nauru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid541"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006900</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nauru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid541">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nauru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid541"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nepal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nepal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid544"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004399</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nepal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid544">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nepal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid544"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid547"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001549</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid547">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid547"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Netherlands_Antilles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Netherlands_Antilles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid550"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004019</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Netherlands Antilles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid550">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Netherlands_Antilles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid550"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Caledonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Caledonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid553"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005206</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Caledonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid553">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid553"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/New_Zealand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/New_Zealand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid556"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000469</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid556">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid556"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nicaragua -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nicaragua">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid559"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002978</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nicaragua</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid559">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid559"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niger -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niger">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid562"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000585</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niger</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid562">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niger"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid562"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Nigeria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Nigeria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid565"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Nigeria</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid565">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid565"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Niue -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Niue">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid568"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Niue Fekai</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006902</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Niue</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid568">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Niue"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid568"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Norfolk_Island -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norfolk_Island">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid571"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norfolk Island</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid571">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid571"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/North_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/North_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid574"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002801</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Democratic People&apos;s Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>North Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid574">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/North_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid574"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
+        <rdfs:label>Northern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_America -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_America">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
+        <rdfs:label>Northern America</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Northern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Northern Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Northern_Mariana_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Northern_Mariana_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003958</oboInOwl:hasDbXref>
@@ -6609,711 +5197,462 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Norway -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Norway">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid579"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Kingdom of Norway</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002699</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Norway</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid579">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Norway"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid579"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Oceania -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Oceania">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
+        <rdfs:label>Oceania</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Oman -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Oman">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005283</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Oman</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid582">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Oman"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid582"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pakistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pakistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid585"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005246</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Pakistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid585">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid585"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006905</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Palau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid588">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid588"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Palestinian_territories -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Palestinian_territories">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid591"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002475</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Occupied Palestinian Territory</oboInOwl:hasExactSynonym>
         <rdfs:label>Palestinian Territories</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid591">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid591"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Panama -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Panama">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid594"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Central_America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002892</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Panama</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid594">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Panama"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid594"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Papua_New_Guinea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Papua_New_Guinea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid597"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003922</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Papua New Guinea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid597">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid597"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Paraguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Paraguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid600"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002933</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Paraguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid600">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid600"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Peru -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Peru">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid603"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002932</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Peru</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid603">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Peru"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid603"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Philippines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Philippines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid606"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>The Philippines</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00004525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Philippines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid606">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Philippines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid606"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Pitcairn_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Pitcairn_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid609"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118 xml:lang="en">Pitcairn</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00005867</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Pitcairn, Henderson, Ducie and Oeno Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>Pitcairn Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid609">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid609"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Poland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Poland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid612"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002939</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Poland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid612">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Poland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid612"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Polynesia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Polynesia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
+        <rdfs:label>Polynesia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Portugal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Portugal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid615"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Portugese Republic</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002944</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Portugal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid615">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Portugal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid615"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Puerto_Rico -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Puerto_Rico">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid618"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000118>Commonwealth of Puerto Rico</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00006935</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Puerto Rico</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid618">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid618"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Qatar -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Qatar">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid621"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005286</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Qatar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid621">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Qatar"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid621"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Ireland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Ireland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid624"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002943</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>Ireland</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Republic of Ireland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid624">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid624"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_Macedonia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_Macedonia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid627"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006895</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">The former Yugoslav Republic of Macedonia</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of Macedonia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid627">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid627"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Republic_of_the_Congo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Republic_of_the_Congo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid630"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001088</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Congo</oboInOwl:hasExactSynonym>
         <rdfs:label>Republic of the Congo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid630">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid630"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Romania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Romania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid633"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002951</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Romania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid633">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Romania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid633"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Russia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Russia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid636"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002721</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Russian Federation</oboInOwl:hasExactSynonym>
         <rdfs:label>Russia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid636">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:allValuesFrom>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Russia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid636"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Rwanda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Rwanda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid642"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001087</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Rwanda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid642">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid642"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Réunion -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Réunion">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid645"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00053746</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Réunion</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid645">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Réunion"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid645"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Helena -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Helena">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid648"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000849</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">St. Helena</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Helena</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid648">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid648"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Kitts_and_Nevis -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Kitts_and_Nevis">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid651"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006906</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Kitts and Nevis</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid651">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid651"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Lucia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Lucia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid654"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006909</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Lucia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid654">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid654"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Martin -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Martin">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005841</oboInOwl:hasDbXref>
@@ -7325,136 +5664,101 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Saint_Pierre_and_Miquelon -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <oboInOwl:hasDbXref>GAZ:00003942</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Saint-Pierre-et-Miquelon</oboInOwl:hasExactSynonym>
         <rdfs:label>Saint Pierre and Miquelon</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid659"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:02000565</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saint Vincent and the Grenadines</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid659">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid659"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Samoa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Samoa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid662"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006910</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Samoa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid662">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Samoa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid662"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/San_Marino -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/San_Marino">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid665"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">San Marino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid665">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid665"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Saudi_Arabia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Saudi_Arabia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid668"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005279</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Saudi Arabia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid668">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid668"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Scandinavia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Scandinavia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Scandinavia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Scotland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Scotland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002639</oboInOwl:hasDbXref>
@@ -7466,146 +5770,91 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Senegal -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Senegal">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid672"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000913</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Senegal</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid672">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Senegal"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid672"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Serbia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Serbia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid675"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002957</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Serbia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid675">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Serbia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid675"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Seychelles -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Seychelles">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid678"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005821</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Seychelles</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid678">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid678"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sierra_Leone -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sierra_Leone">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid681"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sierra Leone</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid681">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid681"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Singapore -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Singapore">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid684"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003923</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Singapore</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid684">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Singapore"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid684"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sint_Maarten -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sint_Maarten">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00012579</oboInOwl:hasDbXref>
@@ -7617,174 +5866,171 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Slovakia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovakia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid688"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002956</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovakia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid688">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid688"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Slovenia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Slovenia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid691"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Slovenia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid691">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid691"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Solomon_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Solomon_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid694"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005275</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Solomon Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid694">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid694"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Somalia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Somalia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid697"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001104</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Somalia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid697">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Somalia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid697"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-Eastern_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-Eastern_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
+        <rdfs:label>South-Eastern Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/South-central_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South-central_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>South-Central Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/SouthAmerica -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/SouthAmerica">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
+        <rdfs:label>South America</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Africa -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Africa">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid700"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">South Africa</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid700">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid700"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/South_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/South_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
+        <rdfs:label>South Asia</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/South_Korea -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Korea">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid703"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002802</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Republic of Korea</oboInOwl:hasExactSynonym>
         <rdfs:label>South Korea</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid703">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/South_Korea"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid703"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/South_Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/South_Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00233439</oboInOwl:hasDbXref>
@@ -7793,209 +6039,163 @@ For example, A and B may be gene products and binding of B by A positively regul
     
 
 
+    <!-- http://dbpedia.org/resource/Southern_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
+        <rdfs:label>Southern Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Southern_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Southern_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Southern Europe</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://dbpedia.org/resource/Spain -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Spain">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid707"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000591</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Spain</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid707">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Spain"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid707"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sri_Lanka -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sri_Lanka">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid710"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003924</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sri Lanka</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid710">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid710"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sudan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sudan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid713"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000560</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid713">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sudan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid713"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Suriname -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Suriname">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid716"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002525</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Suriname</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid716">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Suriname"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid716"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Swaziland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Swaziland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid719"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001099</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Swaziland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid719">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid719"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Sweden -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Sweden">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0288"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid723"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002729</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Sweden</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid723">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Sweden"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid723"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Switzerland -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Switzerland">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid726"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002941</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Switzerland</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid726">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid726"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Syria -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Syria">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002474</oboInOwl:hasDbXref>
@@ -8007,38 +6207,27 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/São_Tomé_and_Príncipe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/São_Tomé_and_Príncipe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid730"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006927</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">São Tomé and Príncipe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid730">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid730"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Taiwan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Taiwan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005341</oboInOwl:hasDbXref>
@@ -8050,814 +6239,535 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Tajikistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tajikistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid734"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006912</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tajikistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid734">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid734"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tanzania -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tanzania">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid737"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001103</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">United Republic of Tanzania</oboInOwl:hasExactSynonym>
         <rdfs:label>Tanzania</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid737">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid737"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Thailand -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Thailand">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid740"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003744</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Thailand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid740">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Thailand"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid740"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Bahamas -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Bahamas">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid743"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002733</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Bahamas</oboInOwl:hasExactSynonym>
         <rdfs:label>The Bahamas</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid743">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid743"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/The_Gambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/The_Gambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid746"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000907</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Gambia</oboInOwl:hasExactSynonym>
         <rdfs:label>The Gambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid746">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid746"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Togo -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Togo">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid749"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000915</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Togo</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid749">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Togo"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid749"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tokelau -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tokelau">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid752"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006914</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tokelau</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid752">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid752"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tonga -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tonga">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid755"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006916</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tonga</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid755">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tonga"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid755"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Trinidad_and_Tobago -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Trinidad_and_Tobago">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid758"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003767</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Trinidad and Tobago</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid758">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid758"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tunisia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tunisia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid761"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000562</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tunisia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid761">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid761"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkey -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkey">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid764"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000558</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkey</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid764">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkey"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid764"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turkmenistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turkmenistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid767"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005018</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turkmenistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid767">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid767"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Turks_and_Caicos_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Turks_and_Caicos_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid770"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003955</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Turks and Caicos Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid770">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid770"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Tuvalu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Tuvalu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid773"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00009715</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Tuvalu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid773">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid773"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uganda -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uganda">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid776"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001102</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uganda</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid776">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uganda"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid776"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Ukraine -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Ukraine">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid779"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002724</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Ukraine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid779">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid779"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Arab_Emirates -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Arab_Emirates">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid782"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005282</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">United Arab Emirates</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid782">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid782"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_Kingdom -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_Kingdom">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid785"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002637</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.K.</oboInOwl:hasExactSynonym>
         <rdfs:label>United Kingdom</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid785">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid785"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <obo:IAO_0000118 xml:lang="en">U.S.</obo:IAO_0000118>
         <oboInOwl:hasDbXref>GAZ:00002459</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>United States of America</oboInOwl:hasExactSynonym>
         <rdfs:label>United States</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/United_States_Virgin_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/United_States_Virgin_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid789"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003959</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">U.S. Virgin Islands</oboInOwl:hasExactSynonym>
         <rdfs:label>United States Virgin Islands</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid789">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid789"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uruguay -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uruguay">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid792"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002930</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uruguay</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid792">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid792"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Uzbekistan -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Uzbekistan">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid795"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004979</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Uzbekistan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid795">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid795"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vanuatu -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vanuatu">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid798"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00006918</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vanuatu</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid798">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid798"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Venezuela -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Venezuela">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid801"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00002931</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Venezuela</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid801">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid801"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Vietnam -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Vietnam">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid804"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00003756</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Vietnam</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid804">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid804"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Wallis_and_Futuna -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Wallis_and_Futuna">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid807"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00007191</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym xml:lang="en">Wallis and Futuna Islands</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Wallis and Futuna</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid807">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid807"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Africa -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Africa">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
+        <rdfs:label>Western Africa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Asia -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Asia">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Asia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://dbpedia.org/resource/Western_Europe -->
+
+    <owl:Class rdf:about="http://dbpedia.org/resource/Western_Europe">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Europe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Western Europe</rdfs:label>
+    </owl:Class>
     
 
 
     <!-- http://dbpedia.org/resource/Western_Sahara -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Western_Sahara">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid810"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00000564</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Western Sahara</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid810">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid810"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Yemen -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Yemen">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid813"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00005284</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Yemen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid813">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Yemen"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid813"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zambia -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zambia">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid816"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001107</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zambia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid816">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zambia"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid816"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Zimbabwe -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Zimbabwe">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid819"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00001106</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Zimbabwe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid819">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid819"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://dbpedia.org/resource/Cocos_(Keeling)_Islands -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Cocos_(Keeling)_Islands">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
@@ -8873,27 +6783,16 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://dbpedia.org/resource/Georgia_(country) -->
 
     <owl:Class rdf:about="http://dbpedia.org/resource/Georgia_(country)">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <rdfs:subClassOf rdf:nodeID="genid823"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCIT_C25464"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref>GAZ:00004942</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">Georgia</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid823">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid823"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -9022,7 +6921,6 @@ For example, A and B may be gene products and binding of B by A positively regul
     <!-- http://purl.obolibrary.org/obo/BFO_0000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
@@ -9035,64 +6933,9 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
             </owl:Restriction>
         </owl:disjointWith>
-        <obo:BFO_0000179>occurrent</obo:BFO_0000179>
-        <obo:BFO_0000180>Occurrent</obo:BFO_0000180>
         <obo:IAO_0000115 xml:lang="en">An entity that has temporal parts and that happens, unfolds or develops through time.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Occurrent doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process.</obo:IAO_0000116>
-        <obo:IAO_0000116>Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by &apos;spn[e]&apos; and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write &apos;spr[e]&apos; and `spl[e]&apos; respectively for the spread and spell of e, omitting mention of the frame.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])</obo:IAO_0000601>
-        <obo:IAO_0000601 xml:lang="en">b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">occurrent</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Occurrent doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000006"/>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget>Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by &apos;spn[e]&apos; and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write &apos;spr[e]&apos; and `spl[e]&apos; respectively for the spread and spell of e, omitting mention of the frame.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000012"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/077-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">Every occurrent occupies_spatiotemporal_region some spatiotemporal region. (axiom label in BFO2 Reference: [108-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/108-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">b is an occurrent entity iff b is an entity that has temporal parts. (axiom label in BFO2 Reference: [079-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/079-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Occurrent x) (exists (r) (and (SpatioTemporalRegion r) (occupiesSpatioTemporalRegion x r))))) // axiom label in BFO2 CLIF: [108-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/108-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (iff (Occurrent x) (and (Entity x) (exists (y) (temporalPartOf y x))))) // axiom label in BFO2 CLIF: [079-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/079-001"/>
-    </owl:Axiom>
     
 
 
@@ -9107,7 +6950,6 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
         <obo:BFO_0000179>ic</obo:BFO_0000179>
         <obo:BFO_0000180>IndependentContinuant</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">a chair</obo:IAO_0000112>
@@ -9173,48 +7015,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000141"/>
-        <obo:BFO_0000179>s-region</obo:BFO_0000179>
-        <obo:BFO_0000180>SpatialRegion</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Spatial regions do not participate in processes.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">Spatial region doesn&apos;t have a closure axiom because the subclasses don&apos;t exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn&apos;t overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">spatial region</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000116"/>
-        <owl:annotatedTarget xml:lang="en">Spatial region doesn&apos;t have a closure axiom because the subclasses don&apos;t exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn&apos;t overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional.</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/0000002"/>
-        <rdfs:comment>per discussion with Barry Smith</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/035-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">All continuant parts of spatial regions are spatial regions. (axiom label in BFO2 Reference: [036-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/036-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x y t) (if (and (SpatialRegion x) (continuantPartOfAt y x t)) (SpatialRegion y))) // axiom label in BFO2 CLIF: [036-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/036-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (SpatialRegion x) (Continuant x))) // axiom label in BFO2 CLIF: [035-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/035-001"/>
-    </owl:Axiom>
     
 
 
@@ -9234,44 +7036,8 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:BFO_0000179>disposition</obo:BFO_0000179>
-        <obo:BFO_0000180>Disposition</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">an atom of element X has the disposition to decay to an atom of element Y</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">certain people have a predisposition to colon cancer</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">children are innately disposed to categorize objects in certain ways.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the cell wall is disposed to filter chemicals in endocytosis and exocytosis</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">disposition</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">b is a disposition means: b is a realizable entity &amp; b’s bearer is some material entity &amp; b is such that if it ceases to exist, then its bearer is physically changed, &amp; b’s realization occurs when and because this bearer is in some special physical circumstances, &amp; this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/062-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">If b is a realizable entity then for all t at which b exists, b s-depends_on some material entity at t. (axiom label in BFO2 Reference: [063-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/063-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x t) (if (and (RealizableEntity x) (existsAt x t)) (exists (y) (and (MaterialEntity y) (specificallyDepends x y t))))) // axiom label in BFO2 CLIF: [063-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/063-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Disposition x) (and (RealizableEntity x) (exists (y) (and (MaterialEntity y) (bearerOfAt x y t)))))) // axiom label in BFO2 CLIF: [062-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/062-002"/>
-    </owl:Axiom>
     
 
 
@@ -9286,45 +7052,9 @@ For example, A and B may be gene products and binding of B by A positively regul
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
-        <obo:BFO_0000179>realizable</obo:BFO_0000179>
-        <obo:BFO_0000180>RealizableEntity</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">the disposition of this piece of metal to conduct electricity.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the disposition of your blood to coagulate</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of your reproductive organs</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of this boundary to delineate where Utah and Colorado meet</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A specifically dependent continuant  that inheres in continuant  entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances.</obo:IAO_0000115>
-        <obo:IAO_0000600 xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</obo:IAO_0000600>
-        <obo:IAO_0000601 xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</obo:IAO_0000601>
-        <obo:IAO_0000602>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] </obo:IAO_0000602>
-        <obo:IAO_0000602>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">realizable entity</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/058-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000601"/>
-        <owl:annotatedTarget xml:lang="en">All realizable dependent continuants have independent continuants that are not spatial regions as their bearers. (axiom label in BFO2 Reference: [060-002])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/060-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x t) (if (RealizableEntity x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (bearerOfAt y x t))))) // axiom label in BFO2 CLIF: [060-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/060-002"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (RealizableEntity x) (and (SpecificallyDependentContinuant x) (exists (y) (and (IndependentContinuant y) (not (SpatialRegion y)) (inheresIn x y)))))) // axiom label in BFO2 CLIF: [058-002] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/058-002"/>
-    </owl:Axiom>
     
 
 
@@ -9391,7 +7121,6 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
         <obo:BFO_0000179>sdc</obo:BFO_0000179>
         <obo:BFO_0000180>SpecificallyDependentContinuant</obo:BFO_0000180>
         <obo:IAO_0000112 xml:lang="en">Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key</obo:IAO_0000112>
@@ -9405,21 +7134,13 @@ For example, A and B may be gene products and binding of B by A positively regul
         <obo:IAO_0000112 xml:lang="en">the role of being a doctor</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the shape of this hole.</obo:IAO_0000112>
         <obo:IAO_0000112 xml:lang="en">the smell of this portion of mozzarella</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &amp;gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &amp;lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">b is a specifically dependent continuant = Def. b is a continuant &amp; there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])</obo:IAO_0000115>
         <obo:IAO_0000116 xml:lang="en">Specifically dependent continuant doesn&apos;t have a closure axiom because the subclasses don&apos;t necessarily exhaust all possibilites. We&apos;re not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc.</obo:IAO_0000116>
-        <obo:IAO_0000602>(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] </obo:IAO_0000602>
         <obo:IAO_0000602>(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] </obo:IAO_0000602>
         <rdfs:comment xml:lang="en">A continuant that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">specifically dependent continuant</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget xml:lang="en">b is a relational specifically dependent continuant = Def. b is a specifically dependent continuant and there are n &amp;gt; 1 independent continuants c1, … cn which are not spatial regions are such that for all 1  i &amp;lt; j  n, ci  and cj share no common parts, are such that for each 1  i  n, b s-depends_on ci at every time t during the course of b’s existence (axiom label in BFO2 Reference: [131-004])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/131-004"/>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -9436,12 +7157,6 @@ For example, A and B may be gene products and binding of B by A positively regul
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(iff (RelationalSpecificallyDependentContinuant a) (and (SpecificallyDependentContinuant a) (forall (t) (exists (b c) (and (not (SpatialRegion b)) (not (SpatialRegion c)) (not (= b c)) (not (exists (d) (and (continuantPartOfAt d b t) (continuantPartOfAt d c t)))) (specificallyDependsOnAt a b t) (specificallyDependsOnAt a c t)))))) // axiom label in BFO2 CLIF: [131-004] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/131-004"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
         <owl:annotatedTarget>(iff (SpecificallyDependentContinuant a) (and (Continuant a) (forall (t) (if (existsAt a t) (exists (b) (and (IndependentContinuant b) (not (SpatialRegion b)) (specificallyDependsOnAt a b t))))))) // axiom label in BFO2 CLIF: [050-003] </owl:annotatedTarget>
         <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/050-003"/>
     </owl:Axiom>
@@ -9452,64 +7167,9 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
-        <obo:BFO_0000179>role</obo:BFO_0000179>
-        <obo:BFO_0000180>Role</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the priest role</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a boundary to demarcate two neighboring administrative territories</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a building in serving as a military target</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of a stone in marking a property boundary</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the role of subject in a clinical trial</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the student role</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A realizable entity  the manifestation of which brings about some result or end that is not essential to a continuant  in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant  in some kinds of natural, social or institutional contexts.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role &amp; c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">b is a role means: b is a realizable entity &amp; b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be&amp; b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">role</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">b is a role means: b is a realizable entity &amp; b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be&amp; b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/061-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Role x) (RealizableEntity x))) // axiom label in BFO2 CLIF: [061-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/061-001"/>
-    </owl:Axiom>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/BFO_0000031 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
-        <obo:BFO_0000179>gdc</obo:BFO_0000179>
-        <obo:BFO_0000180>GenericallyDependentContinuant</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity.</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the pdf file on your laptop, the pdf file that is a copy thereof on my laptop</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule.</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])</obo:IAO_0000115>
-        <obo:IAO_0000602>(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] </obo:IAO_0000602>
-        <rdfs:comment xml:lang="en">A continuant that is dependent on one or other independent continuant bearers. For every instance of A requires some instance of (an independent continuant type) B but which instance of B serves can change from time to time.</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
-        <rdfs:label xml:lang="en">generically dependent continuant</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget xml:lang="en">b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/074-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(iff (GenericallyDependentContinuant a) (and (Continuant a) (exists (b t) (genericallyDependsOnAt a b t)))) // axiom label in BFO2 CLIF: [074-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/074-001"/>
-    </owl:Axiom>
     
 
 
@@ -9517,29 +7177,8 @@ For example, A and B may be gene products and binding of B by A positively regul
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000034">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <obo:BFO_0000179>function</obo:BFO_0000179>
-        <obo:BFO_0000180>Function</obo:BFO_0000180>
-        <obo:IAO_0000112 xml:lang="en">the function of a hammer to drive in nails</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of a heart pacemaker to regulate the beating of a heart through electricity</obo:IAO_0000112>
-        <obo:IAO_0000112 xml:lang="en">the function of amylase in saliva to break down starch into sugar</obo:IAO_0000112>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc.</obo:IAO_0000116>
-        <obo:IAO_0000600 xml:lang="en">A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])</obo:IAO_0000600>
-        <obo:IAO_0000602>(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] </obo:IAO_0000602>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">function</rdfs:label>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
-        <owl:annotatedTarget xml:lang="en">A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])</owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/064-001"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
-        <owl:annotatedTarget>(forall (x) (if (Function x) (Disposition x))) // axiom label in BFO2 CLIF: [064-001] </owl:annotatedTarget>
-        <obo:IAO_0010000 rdf:resource="http://purl.obolibrary.org/obo/bfo/axiom/064-001"/>
-    </owl:Axiom>
     
 
 
@@ -9630,98 +7269,27 @@ For example, A and B may be gene products and binding of B by A positively regul
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
             </owl:Restriction>
         </owl:disjointWith>
-        <obo:BFO_0000179>immaterial</obo:BFO_0000179>
-        <obo:BFO_0000180>ImmaterialEntity</obo:BFO_0000180>
-        <obo:IAO_0000116 xml:lang="en">BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10</obo:IAO_0000116>
-        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
         <rdfs:label xml:lang="en">immaterial entity</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GEO_000000334 -->
+    <!-- http://purl.obolibrary.org/obo/COB_0000032 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000334">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000375"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000137"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label>subcontinental land mass</rdfs:label>
-        <rdfs:label xml:lang="en">subcontinental land mass</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000141"/>
+        <rdfs:label xml:lang="en">geographical location</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/GEO_000000370 -->
+    <!-- http://purl.obolibrary.org/obo/GAZ_00000013 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000370">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-        <obo:IAO_0000111 xml:lang="en">geographical entity of astronomical body</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">A material entity that is (1) a bona fide or fiat object part of the crust, any bodies of liquid on or contained within the crust, or planetary boundary layer (if present) of a terrestrial planet (including Earth), dwarf planet, exoplanet, natural satellite, planetesimal, or small Solar System body, and that (2) overlaps the planetary surface (including having a boundary that coincides with part of the planetary surface).</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Matt Diller</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">William R. Hogan</obo:IAO_0000117>
-        <rdfs:comment xml:lang="en">Includes atmosphere, crust, geographical regions (e.g., the geographical region over which the state of Florida has jurisdiction), bodies of water, mountains, etc.
-
-Generally, an individual organism is a distinct object that is not a part of the Earth, although this requires more thought.  But the intent is definitely for this class to NOT subsume organism universally.  Human beings are contained within, but not part of, the Earth, for example.</rdfs:comment>
-        <rdfs:comment xml:lang="en">Note that despite the word &apos;planetary&apos; in &apos;planetary surface&apos;, it refers generally to surface of dwarf planets, asteroids, moons, etc.</rdfs:comment>
-        <rdfs:comment xml:lang="en">We note that not all planets have a surface per se (e.g., gas giants such as Jupiter and Saturn).  So only planets, natural satellites, etc. with a planetary surface (with or without a planetary boundary layer) have geographical entities.</rdfs:comment>
-        <rdfs:comment xml:lang="en">We note that the term &apos;geography&apos; is also applied to the Earth&apos;s moon, Mars, Venus, and possibly even other moons and planets in our own solar system and beyond.  
-
-Thus, we are attempting to define things generally enough that they could be reused for the geographical entities/features on the Moon, Mars, other planets, exoplanets, other natural satellites (a.k.a moons), asteroids, etc.</rdfs:comment>
-        <rdfs:label xml:lang="en">geographical entity</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000372 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000372">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000370"/>
-        <obo:IAO_0000115 xml:lang="en">A geographical entity that is demarcated at least in part by one or more closed fiat boundaries all of whose lines are part of the planetary surface.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">François Modave</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">Matt Diller</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">William R. Hogan</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">geographical region</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000374 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000374">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000375"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
         <obo:IAO_0000115>One of the large, unbroken masses of land into which the Earth&apos;s surface is divided.</obo:IAO_0000115>
-        <oboInOwl:hasDbXref>GAZ:00190836</oboInOwl:hasDbXref>
         <oboInOwl:hasExactSynonym>major area</oboInOwl:hasExactSynonym>
         <rdfs:label>continent</rdfs:label>
-        <rdfs:label xml:lang="en">continent</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000375 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000375">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000372"/>
-        <rdfs:label>land mass</rdfs:label>
-        <rdfs:label xml:lang="en">land mass</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GEO_000000391 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GEO_000000391">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <obo:IAO_0000111 xml:lang="en">geopolitical organization</obo:IAO_0000111>
-        <obo:IAO_0000117 xml:lang="en">Amanda Hicks</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">geopoli organization</rdfs:label>
-        <rdfs:label>geopolitical organization</rdfs:label>
     </owl:Class>
     
 
@@ -9754,44 +7322,29 @@ Thus, we are attempting to define things generally enough that they could be reu
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000334"/>
-        <rdfs:subClassOf rdf:nodeID="genid895"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000013"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000115>Any geographic area greater than an individual country but smaller than a continent, used as a convenience reference. Please note that most  geographic areas may not be formally defined and exact boundaries can be debatable.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>geographical area</oboInOwl:hasExactSynonym>
         <rdfs:label>region</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid895">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid895"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000391"/>
-        <rdfs:subClassOf rdf:nodeID="genid897"/>
         <obo:IAO_0000115>A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states.</obo:IAO_0000115>
         <obo:IAO_0000119>NCIT:C25464</obo:IAO_0000119>
-        <rdfs:label>country</rdfs:label>
+        <obo:IAO_0100001>http://purl.obolibrary.org/obo/NCIT_C25464</obo:IAO_0100001>
+        <rdfs:label>obsolete country</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid897">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid897"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10093,9 +7646,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000457</oboInOwl:hasDbXref>
-        <rdfs:label>Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Africa"/>
+        <rdfs:label>obsolete Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10103,9 +7656,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000465</oboInOwl:hasDbXref>
-        <rdfs:label>Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Asia"/>
+        <rdfs:label>obsolete Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10113,9 +7666,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0031 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000464</oboInOwl:hasDbXref>
-        <rdfs:label>Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Europe"/>
+        <rdfs:label>obsolete Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10123,9 +7676,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000468</oboInOwl:hasDbXref>
-        <rdfs:label>Oceania</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Oceania"/>
+        <rdfs:label>obsolete Oceania</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10133,9 +7686,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0033 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>Latin America and the Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+        <rdfs:label>obsolete Latin America and the Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10143,9 +7696,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0034 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GEO_000000374"/>
-        <oboInOwl:hasDbXref>GAZ:00000458</oboInOwl:hasDbXref>
-        <rdfs:label>Northern America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_America"/>
+        <rdfs:label>obsolete Northern America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10153,319 +7706,150 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0035 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid909"/>
-        <oboInOwl:hasDbXref>GAZ:00000556</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Africa"/>
+        <rdfs:label>obsolete Eastern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid909">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid909"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid911"/>
-        <rdfs:label>Middle Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Middle_Africa"/>
+        <rdfs:label>obsolete Middle Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid911">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid911"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid913"/>
-        <oboInOwl:hasDbXref>GAZ:00000555</oboInOwl:hasDbXref>
-        <rdfs:label>Northern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Africa"/>
+        <rdfs:label>obsolete Northern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid913">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid913"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0038 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid915"/>
-        <oboInOwl:hasDbXref>GAZ:00000553</oboInOwl:hasDbXref>
-        <rdfs:label>Southern Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Africa"/>
+        <rdfs:label>obsolete Southern Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid915">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid915"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0039 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid917"/>
-        <oboInOwl:hasDbXref>GAZ:00000554</oboInOwl:hasDbXref>
-        <rdfs:label>Western Africa</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Africa"/>
+        <rdfs:label>obsolete Western Africa</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid917">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid917"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0041 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid919"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label>South-Central Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-central_Asia"/>
+        <rdfs:label>obsolete South Central Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid919">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid919"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0042 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid922"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0289"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <oboInOwl:hasDbXref>GAZ:00000559</oboInOwl:hasDbXref>
-        <rdfs:label>South-Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South-Eastern_Asia"/>
+        <rdfs:label>obsolete South-Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid922">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid922"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid925"/>
-        <rdfs:label>Western Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Asia"/>
+        <rdfs:label>obsolete Western Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid925">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid925"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0044 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid927"/>
-        <rdfs:label>Eastern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Europe"/>
+        <rdfs:label>obsolete Eastern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid927">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid927"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0045 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid929"/>
-        <rdfs:label>Northern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Northern_Europe"/>
+        <rdfs:label>obsolete Northern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid929">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid929"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid931"/>
-        <rdfs:label>Southern Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Southern_Europe"/>
+        <rdfs:label>obsolete Southern Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid931">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid931"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0047 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid933"/>
-        <rdfs:label>Western Europe</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Western_Europe"/>
+        <rdfs:label>obsolete Western Europe</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid933">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid933"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0048 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid935"/>
-        <rdfs:label>Caribbean</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Caribbean"/>
+        <rdfs:label>obsolete Caribbean</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid935">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid935"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0049 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid937"/>
-        <oboInOwl:hasDbXref>GAZ:00000459</oboInOwl:hasDbXref>
-        <rdfs:label>South America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/SouthAmerica"/>
+        <rdfs:label>obsolete South America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid937">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid937"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid939"/>
-        <oboInOwl:hasDbXref>GAZ:00002891</oboInOwl:hasDbXref>
-        <rdfs:label>Central America</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Central_America"/>
+        <rdfs:label>obsolete Central America</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid939">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid939"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10473,103 +7857,54 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid941"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:allValuesFrom rdf:resource="http://dbpedia.org/resource/Oceania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label>Australia/New Zealand</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid941">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid941"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0052 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid943"/>
-        <oboInOwl:hasDbXref>GAZ:00005860</oboInOwl:hasDbXref>
-        <rdfs:label>Melanesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Melanesia"/>
+        <rdfs:label>obsolete Melanesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid943">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid943"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0053 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid945"/>
-        <oboInOwl:hasDbXref>GAZ:00005862</oboInOwl:hasDbXref>
-        <rdfs:label>Micronesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Micronesia"/>
+        <rdfs:label>obsolete Micronesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid945">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid945"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid947"/>
-        <oboInOwl:hasDbXref>GAZ:00005861</oboInOwl:hasDbXref>
-        <rdfs:label>Polynesia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Polynesia"/>
+        <rdfs:label>obsolete Polynesia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid947">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid947"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf rdf:nodeID="genid949"/>
-        <oboInOwl:hasDbXref>GAZ:00002471</oboInOwl:hasDbXref>
-        <rdfs:label>Eastern Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Eastern_Asia"/>
+        <rdfs:label>obsolete Eastern Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid949">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid949"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10586,14 +7921,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0288 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0288">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label xml:lang="en">Scandinavia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/Scandinavia"/>
+        <rdfs:label>obsolete Scandinavia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10601,9 +7931,9 @@ from this region. This category includes individuals with known admixture of pri
     <!-- http://purl.obolibrary.org/obo/HANCESTRO_0289 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0289">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
-        <oboInOwl:hasDbXref>GAZ:00002472</oboInOwl:hasDbXref>
-        <rdfs:label xml:lang="en">South Asia</rdfs:label>
+        <obo:IAO_0100001 rdf:resource="http://dbpedia.org/resource/South_Asia"/>
+        <rdfs:label>obsolete South Asia</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -10669,19 +7999,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0307">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid956"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Italian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid956">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Italy"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0307"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid956"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -10918,19 +8243,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0321">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid976"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Finnish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid976">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Finland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0321"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid976"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11007,25 +8327,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0331">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid984"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid984">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0331"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid984"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11033,25 +8342,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0332">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid987"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sahrawi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid987">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Western_Sahara"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0332"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid987"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11059,25 +8357,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0333">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid990"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Anguillan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid990">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Anguilla"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0333"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid990"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11085,25 +8372,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid993"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Antiguan or Barbudan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid993">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Antigua_and_Barbuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0334"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid993"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11111,25 +8387,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0335">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid996"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Barbadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid996">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Barbados"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0335"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid996"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11137,25 +8402,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0336">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid999"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Haitian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid999">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Haiti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid999"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0336"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11163,25 +8417,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <rdfs:subClassOf rdf:nodeID="genid1002"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jamaican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1002">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jamaica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0337"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1002"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11189,25 +8432,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0338">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1005"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tajikistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1005">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tajikistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0338"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1005"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11215,25 +8447,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1008"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkmen</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1008">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkmenistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0339"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11241,25 +8462,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1011"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uzbekistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1011">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uzbekistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0340"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11267,19 +8477,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0341">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Afghan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1013">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Afghanistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0341"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1013"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11287,25 +8492,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0342">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1016"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kazakhstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1016">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kazakhstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0342"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1016"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11313,25 +8507,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1019"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kyrgyzstani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1019">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kyrgyzstan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0343"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1019"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11339,19 +8522,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0344">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1021"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Albanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1021">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Albania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0344"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1021"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11359,19 +8537,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0345">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1023"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Andorran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1023">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Andorra"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0345"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1023"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11379,19 +8552,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0346">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1025"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Australian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1025">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Australia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0346"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1025"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11399,19 +8567,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0347">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Austrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1027">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Austria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0347"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1027"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11419,19 +8582,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0348">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1029"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belarusian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1029">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belarus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0348"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1029"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11439,19 +8597,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1031"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1031">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belgium"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0349"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1031"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11459,19 +8612,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0350">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1033"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bermudian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1033">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bermuda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0350"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1033"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11479,19 +8627,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0351">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1035"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bosnian or Herzegovinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1035">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bosnia_and_Herzegovina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0351"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1035"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11499,19 +8642,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1037"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Brazilian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1037">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brazil"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0352"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1037"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11519,19 +8657,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1039"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bulgarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1039">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bulgaria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0353"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1039"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11539,19 +8672,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0354">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1041"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Canadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1041">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Canada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0354"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1041"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11559,19 +8687,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0355">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1043"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Channel Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1043">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Channel_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0355"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1043"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11579,19 +8702,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0356">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1045"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chilean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1045">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chile"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0356"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1045"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11599,19 +8717,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0357">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1047"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Croatian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1047">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Croatia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0357"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1047"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11619,19 +8732,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0358">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1049"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Czech</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1049">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Czech_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0358"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1049"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11639,19 +8747,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0359">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1051"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Danish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1051">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Denmark"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0359"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1051"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11659,19 +8762,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0360">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1053"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Estonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1053">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Estonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0360"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1053"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11679,19 +8777,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0361">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1055"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Faroese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1055">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Faeroe_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0361"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1055"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11699,19 +8792,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0362">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1057"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Falkland Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1057">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Falkland_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0362"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1057"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11719,19 +8807,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0363">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1059"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1059">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/France"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0363"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1059"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11739,19 +8822,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0364">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1061"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">German</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1061">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Germany"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0364"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1061"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11759,19 +8837,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0365">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1063"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gibraltarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1063">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gibraltar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0365"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1063"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11779,19 +8852,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1065"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greek</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1065">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greece"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0366"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1065"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11799,19 +8867,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0367">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1067"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Greenlander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1067">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Greenland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0367"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1067"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11819,19 +8882,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0368">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1069"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Hungarian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1069">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Hungary"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0368"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1069"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11839,19 +8897,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0369">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1071"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Icelandic</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1071">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iceland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0369"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1071"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11859,19 +8912,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0370">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1073"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Manx</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1073">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Isle_of_Man"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0370"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1073"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11879,19 +8927,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0371">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1075"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Latvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1075">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Latvia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0371"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1075"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11899,19 +8942,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0372">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1077"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liechtensteiner</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1077">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liechtenstein"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0372"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1077"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11919,19 +8957,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0373">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1079"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lithuanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1079">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lithuania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0373"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1079"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11939,19 +8972,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1081"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Luxembourgish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1081">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Luxembourg"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0374"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1081"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11959,19 +8987,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0375">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1083"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maltese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1083">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malta"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0375"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1083"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11979,19 +9002,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0376">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1085"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Monegasque</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1085">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Monaco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0376"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1085"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -11999,19 +9017,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0377">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1087"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montenegrin</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1087">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montenegro"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0377"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1087"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12019,19 +9032,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0378">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1089"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Zealandish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1089">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Zealand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0378"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1089"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12040,7 +9048,12 @@ from this region. This category includes individuals with known admixture of pri
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0379">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0290"/>
-        <rdfs:subClassOf rdf:nodeID="genid1092"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0301"/>
@@ -12053,8 +9066,8 @@ from this region. This category includes individuals with known admixture of pri
                 <owl:allValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://dbpedia.org/resource/Polynesia"/>
                             <rdf:Description rdf:about="http://dbpedia.org/resource/United_Kingdom"/>
-                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
                         </owl:intersectionOf>
                     </owl:Class>
                 </owl:allValuesFrom>
@@ -12062,22 +9075,6 @@ from this region. This category includes individuals with known admixture of pri
         </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norfolk Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1092">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norfolk_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0379"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1092"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12085,19 +9082,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0380">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1099"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Norwegian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1099">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Norway"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0380"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1099"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12105,19 +9097,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0381">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1101"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Polish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1101">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Poland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0381"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1101"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12125,19 +9112,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0382">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1103"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Portugese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1103">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Portugal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0382"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1103"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12145,19 +9127,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0383">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1105"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Irish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1105">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Ireland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0383"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1105"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12165,19 +9142,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0384">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1107"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moldovan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1107">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Moldova"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0384"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1107"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12185,19 +9157,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0385">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1109"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Romanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1109">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Romania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0385"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1109"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12205,25 +9172,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1112"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Russian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1112">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Russia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0386"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1112"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12231,19 +9187,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0387">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1114"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint-Pierrais or Miquelonnais</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1114">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Pierre_and_Miquelon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0387"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1114"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12251,19 +9202,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0388">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1116"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sammarinese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1116">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/San_Marino"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0388"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1116"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12271,19 +9217,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0389">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1118"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Serb</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1118">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Serbia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0389"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1118"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12291,19 +9232,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0390">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1120"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovak</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1120">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovakia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0390"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1120"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12311,19 +9247,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0391">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1122"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Slovene</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1122">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Slovenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0391"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1122"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12331,19 +9262,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0392">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1124"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Spanish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1124">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Spain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0392"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1124"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12351,19 +9277,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0393">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1126"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swedish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1126">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sweden"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0393"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1126"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12371,19 +9292,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0394">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1128"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swiss</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1128">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Switzerland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0394"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1128"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12391,19 +9307,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1130"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Macedonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1130">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_Macedonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0395"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1130"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12411,19 +9322,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1132"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ukrainian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1132">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ukraine"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0396"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1132"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12431,25 +9337,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1135"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Argentine</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1135">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Argentina"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0397"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1135"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12457,25 +9352,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0398">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1138"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahamian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1138">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Bahamas"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0398"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1138"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12483,25 +9367,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1141"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Belizean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1141">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Belize"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0399"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1141"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12509,25 +9382,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1144"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bolivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1144">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bolivia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0400"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1144"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12535,25 +9397,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0401">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1147"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1147">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/British_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0401"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1147"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12561,25 +9412,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1150"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Caymanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1150">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cayman_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0402"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1150"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12587,25 +9427,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0403">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1153"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Colombian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1153">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Colombia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0403"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1153"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12613,25 +9442,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0404">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1156"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Costa Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1156">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Costa_Rica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0404"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1156"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12639,25 +9457,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0405">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1159"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cuban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1159">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cuba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0405"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1159"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12665,25 +9472,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0406">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1162"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Dominican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1162">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Dominica"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0406"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1162"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12691,25 +9487,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0407">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1165"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ecuadorian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1165">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ecuador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0407"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1165"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12717,25 +9502,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0408">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1168"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Salvadoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1168">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/El_Salvador"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0408"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1168"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12743,25 +9517,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0409">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1171"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Guianese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1171">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Guiana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0409"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1171"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12769,25 +9532,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0410">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1174"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Grenadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1174">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Grenada"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0410"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1174"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12795,25 +9547,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0411">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1177"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guatemalan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1177">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guatemala"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0411"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1177"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12821,25 +9562,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0412">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1180"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guyanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1180">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guyana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0412"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1180"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12847,25 +9577,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0413">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1183"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Honduran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1183">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Honduras"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0413"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1183"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12873,25 +9592,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0414">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1186"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Martinican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1186">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Martinique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0414"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1186"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12899,25 +9607,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0415">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1189"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mexican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1189">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mexico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0415"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1189"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12925,25 +9622,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0416">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1192"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Montserratian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1192">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Montserrat"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0416"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1192"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12951,25 +9637,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0417">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1195"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nicaraguan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1195">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nicaragua"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0417"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1195"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -12977,25 +9652,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0418">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1198"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Panamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1198">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Panama"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0418"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1198"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13003,25 +9667,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0419">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1201"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Paraguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1201">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Paraguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0419"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1201"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13029,25 +9682,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1204"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Peruvian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1204">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Peru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0420"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1204"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13055,25 +9697,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0421">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <rdfs:subClassOf rdf:nodeID="genid1207"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Puerto Rican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1207">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Puerto_Rico"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0014"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0421"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1207"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13081,25 +9712,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1210"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kittitian or Nevisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1210">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Kitts_and_Nevis"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0422"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1210"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13107,25 +9727,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0423">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1213"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Lucian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1213">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Lucia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0423"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1213"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13133,25 +9742,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0424">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1216"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Saint Vincentian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1216">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Vincent_and_the_Grenadines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0424"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1216"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13159,26 +9757,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0425">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1219"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Surinamer</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Surinamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1219">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Suriname"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0425"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1219"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13186,25 +9773,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0426">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1222"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Trinidadian or Tobagonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1222">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Trinidad_and_Tobago"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0426"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1222"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13212,25 +9788,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0427">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1225"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turks and Caicos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1225">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turks_and_Caicos_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0427"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1225"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13238,25 +9803,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0428">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1228"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Virgin Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1228">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States_Virgin_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0428"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1228"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13264,25 +9818,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0429">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1231"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Uruguayan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1231">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uruguay"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0429"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1231"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13290,25 +9833,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0430">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1234"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Venezuelan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1234">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Venezuela"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0430"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1234"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13316,25 +9848,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0431">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1237"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Algerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1237">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Algeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0431"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1237"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13342,25 +9863,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1240"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Armenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1240">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Armenia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0432"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1240"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13368,25 +9878,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0433">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1243"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Azerbaijani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1243">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Azerbaijan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0433"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1243"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13394,25 +9893,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0434">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1246"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bahraini</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1246">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bahrain"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0434"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1246"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13420,25 +9908,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0435">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1249"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cypriote</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1249">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cyprus"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0435"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1249"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13446,25 +9923,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0436">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1252"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Egyptian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1252">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Egypt"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0436"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1252"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13472,25 +9938,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0437">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1255"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Georgian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1255">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Georgia_(country)"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0437"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1255"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13498,25 +9953,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0438">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1258"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iranian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1258">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iran"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0438"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1258"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13524,25 +9968,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0439">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1261"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Iraqi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1261">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Iraq"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0439"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1261"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13550,25 +9983,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0440">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1264"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Israeli</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1264">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Israel"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0440"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1264"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13576,25 +9998,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0441">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1267"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Jordanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1267">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Jordan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0441"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1267"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13602,25 +10013,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1270"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kuwaiti</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1270">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kuwait"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0442"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1270"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13628,25 +10028,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1273"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lebanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1273">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lebanon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0443"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1273"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13654,25 +10043,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0444">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1276"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Libyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1276">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Libya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0444"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1276"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13680,25 +10058,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0445">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1279"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Moroccan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1279">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Morocco"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0445"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1279"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13706,25 +10073,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0446">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1282"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palestinian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1282">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palestinian_territories"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0446"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1282"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13732,25 +10088,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0447">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1285"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Omani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1285">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Oman"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0447"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1285"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13758,25 +10103,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0448">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1288"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Qatari</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1288">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Qatar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0448"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1288"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13784,26 +10118,15 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0449">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1291"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Saudi Arab</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Saudi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1291">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saudi_Arabia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0449"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1291"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13811,25 +10134,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0450">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1294"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tunisian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1294">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tunisia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0450"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1294"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13837,25 +10149,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0451">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <rdfs:subClassOf rdf:nodeID="genid1297"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Turkish</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1297">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Turkey"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0018"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0451"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1297"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13863,25 +10164,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0452">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1300"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Emirati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1300">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Arab_Emirates"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0452"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1300"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13889,25 +10179,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0453">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1303"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Yemeni</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1303">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Yemen"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0453"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1303"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13915,25 +10194,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0454">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1306"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Aruban</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1306">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Aruba"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0454"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1306"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13941,25 +10209,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0455">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1309"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Christmas Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1309">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Christmas_Island"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0455"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1309"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13967,25 +10224,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0456">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1312"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cocos Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1312">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cocos_(Keeling)_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0456"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1312"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -13993,25 +10239,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0457">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1315"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Curacaoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1315">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Curacao"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0457"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1315"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14019,25 +10254,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0458">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1318"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kosovar</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1318">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kosovo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0458"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1318"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14045,25 +10269,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0459">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1321"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Northern Mariana Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1321">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Northern_Mariana_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0459"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1321"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14071,25 +10284,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0460">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1324"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South Sudanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1324">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Sudan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0460"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1324"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14097,25 +10299,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0461">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <rdfs:subClassOf rdf:nodeID="genid1327"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Syrian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1327">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Syria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0015"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0461"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1327"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14123,19 +10314,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0462">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0005"/>
-        <rdfs:subClassOf rdf:nodeID="genid1329"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">British</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1329">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_Kingdom"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0462"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1329"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14143,25 +10329,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1332"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1332">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/United_States"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0463"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1332"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14169,25 +10344,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0464">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1335"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">American Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1335">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/American_Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0464"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1335"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14195,25 +10359,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0465">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1338"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cook Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1338">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cook_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0465"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1338"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14221,25 +10374,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1341"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Fijian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1341">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Fiji"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0466"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1341"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14247,25 +10389,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0467">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1344"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">French Polynesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1344">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/French_Polynesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0467"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1344"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14273,25 +10404,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1347"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guamanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1347">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0468"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1347"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14299,25 +10419,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1350"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">I-Kiribati</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1350">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kiribati"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0469"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1350"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14325,25 +10434,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0470">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1353"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Marshallese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1353">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Marshall_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0470"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1353"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14351,25 +10449,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1356"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Micronesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1356">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Federated_States_of_Micronesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0471"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1356"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14377,25 +10464,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0472">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1359"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nauruan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1359">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nauru"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0472"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1359"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14403,25 +10479,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0473">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1362"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">New Caledonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1362">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/New_Caledonia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0473"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1362"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14429,25 +10494,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0474">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1365"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Niuean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1365">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niue"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0474"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1365"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14455,25 +10509,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0475">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1368"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Palauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1368">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Palau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0475"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1368"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14481,25 +10524,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1371"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Papua New Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1371">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Papua_New_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0476"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1371"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14507,25 +10539,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0477">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1374"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pitcairn Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1374">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pitcairn_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0477"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1374"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14533,25 +10554,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0478">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1377"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Samoan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1377">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Samoa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0478"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1377"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14559,25 +10569,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <rdfs:subClassOf rdf:nodeID="genid1380"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Solomon Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1380">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Solomon_Islands"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0017"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0479"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1380"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14585,25 +10584,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0480">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1383"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tokelauan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1383">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tokelau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0480"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1383"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14611,25 +10599,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0481">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1386"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tongan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1386">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tonga"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0481"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1386"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14637,25 +10614,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0482">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1389"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tuvaluan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1389">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tuvalu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0482"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1389"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14663,25 +10629,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0483">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1392"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ni-Vanuato</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1392">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vanuatu"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0483"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1392"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14689,25 +10644,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1395"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Wallis and Futuna Islander</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1395">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Wallis_and_Futuna"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0484"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1395"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14715,25 +10659,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1398"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bangladeshi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1398">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bangladesh"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0485"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1398"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14741,25 +10674,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1401"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bhutanese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1401">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Bhutan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0486"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1401"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14767,27 +10689,16 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0487">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1404"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasExactSynonym>Asian Indian</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Indian Asian</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Indian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1404">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/India"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0487"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1404"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14795,25 +10706,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0488">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1407"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Maldivian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1407">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Maldives"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0488"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1407"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14821,25 +10721,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0489">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1410"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nepalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1410">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nepal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0489"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1410"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14847,25 +10736,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0490">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1413"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Pakistani</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1413">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Pakistan"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0490"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1413"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14873,25 +10751,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0491">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <rdfs:subClassOf rdf:nodeID="genid1416"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sri Lankan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1416">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sri_Lanka"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0006"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0491"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1416"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14899,25 +10766,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0492">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1419"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bruneian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1419">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Brunei"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0492"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1419"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14925,25 +10781,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0493">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1422"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cambodian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1422">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cambodia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0493"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1422"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14951,25 +10796,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1425"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Indonesian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1425">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Indonesia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0494"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1425"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -14977,25 +10811,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1428"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Lao</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1428">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Laos"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0495"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1428"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15003,25 +10826,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0496">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1431"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malaysian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1431">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malaysia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0496"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1431"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15029,25 +10841,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0497">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1434"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burmese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1434">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Myanmar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0497"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1434"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15055,25 +10856,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0498">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <rdfs:subClassOf rdf:nodeID="genid1437"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Filipino</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1437">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Philippines"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0008"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0498"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1437"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15081,25 +10871,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1440"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Thai</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1440">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Thailand"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0500"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1440"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15107,25 +10886,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1443"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Timorese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1443">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/East_Timor"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0501"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1443"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15133,25 +10901,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <rdfs:subClassOf rdf:nodeID="genid1446"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Vietnamese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1446">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Vietnam"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0007"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0502"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1446"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15159,25 +10916,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1449"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cameroonian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1449">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cameroon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0503"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1449"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15185,19 +10931,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1451"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Cape Verdean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1451">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Cape_Verde"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0504"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1451"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15205,25 +10946,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0505">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1454"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Chadian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1454">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Chad"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0505"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1454"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15231,25 +10961,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0506">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1457"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ethiopian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1457">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ethiopia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0506"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1457"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15257,25 +10976,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1460"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Kenyan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1460">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Kenya"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0507"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1460"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15283,25 +10991,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1463"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Liberian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1463">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Liberia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0508"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1463"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15309,25 +11006,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0509">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1466"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malagasy</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1466">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Madagascar"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0509"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1466"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15335,25 +11021,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0510">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1469"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1469">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauretania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0510"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1469"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15361,25 +11036,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0511">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1472"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mauritian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1472">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mauritius"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0511"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1472"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15387,25 +11051,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0512">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1475"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mahoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1475">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mayotte"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0512"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1475"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15413,25 +11066,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0513">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1478"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Namibian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1478">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Namibia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0513"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1478"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15439,25 +11081,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1481"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sao Tomean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1481">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/São_Tomé_and_Príncipe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0514"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1481"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15465,25 +11096,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0515">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1484"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Senegalese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1484">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Senegal"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0515"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1484"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15491,25 +11111,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0516">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1487"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Seychellois</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1487">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Seychelles"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0516"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1487"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15517,25 +11126,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1490"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Sierra Leonean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1490">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Sierra_Leone"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0517"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1490"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15543,25 +11141,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0518">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1493"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Somali</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1493">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Somalia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0518"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1493"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15569,25 +11156,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0519">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1496"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">South African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1496">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/South_Africa"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0519"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1496"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15595,25 +11171,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0520">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1499"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">St. Helenian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1499">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Saint_Helena"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0520"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1499"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15621,25 +11186,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0521">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1502"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ugandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1502">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Uganda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0521"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1502"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15647,25 +11201,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0522">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1505"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Angolan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1505">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Angola"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0522"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1505"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15673,25 +11216,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0523">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1508"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Beninese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1508">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Benin"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0523"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1508"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15699,25 +11231,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0524">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1511"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Motswana</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1511">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Botswana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0524"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1511"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15725,25 +11246,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0525">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1514"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burkinabe</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1514">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burkina_Faso"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0525"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1514"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15751,25 +11261,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0526">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1517"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Burundian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1517">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Burundi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0526"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1517"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15777,25 +11276,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0527">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1520"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Central African</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1520">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Central_African_Republic"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0527"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1520"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15803,25 +11291,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0528">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1523"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Comoran</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1523">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Comoros"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0528"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1523"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15829,36 +11306,20 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0529">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1526"/>
-        <rdfs:subClassOf rdf:nodeID="genid1528"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Congolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1526">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Democratic_Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Restriction rdf:nodeID="genid1528">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Republic_of_the_Congo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1526"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0529"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1528"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15866,25 +11327,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1531"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ivoirian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1531">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ivory_Coast"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0530"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1531"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15892,25 +11342,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0531">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1534"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Djiboutian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1534">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Djibouti"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0531"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1534"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15918,25 +11357,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0532">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1537"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Equatorial Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1537">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Equatorial_Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0532"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1537"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15944,25 +11372,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0533">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1540"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Eritrean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1540">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Eritrea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0533"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1540"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15970,25 +11387,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0534">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1543"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gabonese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1543">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Gabon"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0534"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1543"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -15996,25 +11402,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0535">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1546"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Gambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1546">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/The_Gambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0535"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1546"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16022,25 +11417,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0536">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1549"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Ghanaian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1549">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Ghana"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0536"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1549"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16048,25 +11432,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0537">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1552"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1552">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0537"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1552"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16074,25 +11447,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0538">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1555"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Bissau-Guinean</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1555">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Guinea_Bissau"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0538"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1555"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16100,25 +11462,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0539">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1558"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mosotho</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1558">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Lesotho"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0539"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1558"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16126,25 +11477,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0540">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1561"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malawian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1561">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Malawi"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0540"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1561"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16152,25 +11492,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0541">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1564"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Malian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1564">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mali"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0541"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1564"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16178,25 +11507,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0542">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1567"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Mozambican</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1567">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Mozambique"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0542"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1567"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16204,25 +11522,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0543">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1570"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerien</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1570">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Niger"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0543"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1570"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16230,25 +11537,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0544">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1573"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Nigerian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1573">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Nigeria"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0544"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1573"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16256,25 +11552,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0545">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1576"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Rwandan</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1576">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Rwanda"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0545"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1576"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16282,25 +11567,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0546">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1579"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Swazi</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1579">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Swaziland"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0546"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1579"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16308,19 +11582,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0547">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1581"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Togolese</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1581">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Togo"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0547"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1581"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16328,19 +11597,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0548">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0011"/>
-        <rdfs:subClassOf rdf:nodeID="genid1583"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Tanzanian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1583">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Tanzania"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0548"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1583"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16348,19 +11612,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0549">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1585"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zambian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1585">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zambia"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0549"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1585"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16368,25 +11627,14 @@ from this region. This category includes individuals with known admixture of pri
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0550">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <rdfs:subClassOf rdf:nodeID="genid1588"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
+                <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Zimbabweian</rdfs:label>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid1588">
-        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0330"/>
-        <owl:someValuesFrom rdf:resource="http://dbpedia.org/resource/Zimbabwe"/>
-    </owl:Restriction>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0566"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0550"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid1588"/>
-        <terms:contributor>http://e-lico.eu/populous#OPPL_pattern</terms:contributor>
-    </owl:Axiom>
     
 
 
@@ -16988,6 +12236,22 @@ category does not include all native populations within the Arctic circle for ex
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCIT_C25464 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C25464">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000032"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+                <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/HANCESTRO_0002"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115>A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states.</obo:IAO_0000115>
+        <rdfs:label>Country</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/OBI_0000181 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000181">
@@ -17117,45 +12381,39 @@ for now.</obo:IAO_0000116>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000020"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Latin_America_and_the_Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Oceania"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0029"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0030"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0031"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0032"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0033"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0034"/>
-        </owl:members>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
-        <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0035"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0036"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0037"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0038"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0039"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0041"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0042"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0043"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0044"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0045"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0046"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0047"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0048"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0049"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0050"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Caribbean"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Central_America"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Eastern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Melanesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Micronesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Middle_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Northern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Polynesia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Scandinavia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-Eastern_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South-central_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/SouthAmerica"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/South_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Southern_Europe"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Africa"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Asia"/>
+            <rdf:Description rdf:about="http://dbpedia.org/resource/Western_Europe"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0051"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0052"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0053"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0054"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/HANCESTRO_0055"/>
         </owl:members>
     </rdf:Description>
     

--- a/src/ontology/components/dbpedia_geography.owl
+++ b/src/ontology/components/dbpedia_geography.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/hancestro/components/dbpedia_geography.owl>
-<http://purl.obolibrary.org/obo/hancestro/releases/2024-01-22/components/dbpedia_geography.owl>
-Annotation(owl:versionInfo "2024-01-22")
+<http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/components/dbpedia_geography.owl>
+Annotation(owl:versionInfo "2024-01-24")
 
 Declaration(Class(<http://dbpedia.org/resource/Africa>))
 Declaration(Class(<http://dbpedia.org/resource/Asia>))

--- a/src/ontology/components/gaz_xrefs.owl
+++ b/src/ontology/components/gaz_xrefs.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/hancestro/components/gaz_xrefs.owl>
-<http://purl.obolibrary.org/obo/hancestro/releases/2024-01-22/components/gaz_xrefs.owl>
-Annotation(owl:versionInfo "2024-01-22")
+<http://purl.obolibrary.org/obo/hancestro/releases/2024-01-24/components/gaz_xrefs.owl>
+Annotation(owl:versionInfo "2024-01-24")
 
 Declaration(Class(<http://dbpedia.org/resource/Afghanistan>))
 Declaration(Class(<http://dbpedia.org/resource/Africa>))


### PR DESCRIPTION
This release includes a full restructure of the geographical entities in HANCESTRO. Changes include:
- migration of geographical entities from `material entity` to `immaterial entity`
- grouping of countries, regions and continents under the COB term `geographical location (COB:0000032)`
- replacement of `continent (GEO:000000374)` with `continent (GAZ:00000013)`
- replacement of `country (HANCESTRO:0003)` with `Country (NCIT:C25464)`
- obsoletion of all HANCESTRO native regions and continents in favour of their equivalent DBPEDIA IRIs (except for `Australia/New Zealand (HANCESTRO:0051)` which has no equivalent DBPEDIA term)
- existing annotation properties and class axioms were preserved and migrated wherever possible